### PR TITLE
fix(FEV-933): fix "Hide button" location

### DIFF
--- a/src/components/pip-minimized/pip-minimized.scss
+++ b/src/components/pip-minimized/pip-minimized.scss
@@ -1,5 +1,8 @@
 @import '~styles/styles';
 
+$show-container-height: 32px;
+$show-container-gap: 5px;
+
 .childPlayerContainer {
   position: absolute;
   top: 0;
@@ -28,10 +31,9 @@
 
     position: absolute;
     width: 66px;
-    height: 32px;
+    height: $show-container-height;
     right: 0px;
-    top: 0px;
-    transform: translateY(calc(-100% - 5px));
+    top: calc((#{$show-container-height} + #{$show-container-gap}) * -1);
 
     color: #ffffff;
     font-style: normal;

--- a/src/components/pip-minimized/pip-minimized.tsx
+++ b/src/components/pip-minimized/pip-minimized.tsx
@@ -34,7 +34,13 @@ export class PipMinimized extends Component<PIPMinimizedProps> {
           <Button onClick={show} className={styles.showContainer}>
             <Fragment>
               <div className={styles.iconContainer}>
-                <Icon id="dualscreen-pip-minimized-show" height={icons.SmallSize} width={icons.SmallSize} viewBox={`0 0 ${icons.SmallSize} ${icons.SmallSize}`} path={icons.SHOW_ICON_PATH} />
+                <Icon
+                  id="dualscreen-pip-minimized-show"
+                  height={icons.SmallSize}
+                  width={icons.SmallSize}
+                  viewBox={`0 0 ${icons.SmallSize} ${icons.SmallSize}`}
+                  path={icons.SHOW_ICON_PATH}
+                />
               </div>
               {Labels.Show}
             </Fragment>
@@ -42,7 +48,13 @@ export class PipMinimized extends Component<PIPMinimizedProps> {
         )}
         <Button onClick={onInverse} className={[styles.innerButtons, hideButtons ? styles.tinyInnerButtons : ''].join(' ')}>
           <div className={styles.iconContainer}>
-            <Icon id="dualscreen-pip-minimized-swap" height={icons.MediumSize} width={icons.MediumSize} viewBox={`0 0 ${icons.MediumSize} ${icons.MediumSize}`}path={icons.SWAP_ICON_PATH} />
+            <Icon
+              id="dualscreen-pip-minimized-swap"
+              height={icons.MediumSize}
+              width={icons.MediumSize}
+              viewBox={`0 0 ${icons.MediumSize} ${icons.MediumSize}`}
+              path={icons.SWAP_ICON_PATH}
+            />
           </div>
         </Button>
       </Fragment>

--- a/src/components/pip/pip-child.tsx
+++ b/src/components/pip/pip-child.tsx
@@ -37,7 +37,7 @@ export class PipChild extends Component<PIPChildComponentProps> {
 
   componentDidMount() {
     const {player} = this.props;
-    this.playerContainerRef?.current?.appendChild(player.getView());
+    this.playerContainerRef?.current?.prepend(player.getView());
   }
 
   private _renderInnerButtons() {
@@ -45,10 +45,22 @@ export class PipChild extends Component<PIPChildComponentProps> {
     return (
       <div className={styles.innerButtons}>
         <Button className={styles.iconContainer} onClick={onInversePIP} tooltip={{label: Labels.SwitchScreen, type: 'bottom-left'}}>
-          <Icon id="dualscreen-pip-swap" height={icons.MediumSize} width={icons.MediumSize} path={icons.SWAP_ICON_PATH} />
+          <Icon
+            id="dualscreen-pip-swap"
+            height={icons.MediumSize}
+            width={icons.MediumSize}
+            viewBox={`0 0 ${icons.MediumSize} ${icons.MediumSize}`}
+            path={icons.SWAP_ICON_PATH}
+          />
         </Button>
         <Button className={styles.iconContainer} onClick={onSideBySideSwitch} tooltip={{label: Labels.SideBySide, type: 'bottom'}}>
-          <Icon id="dualscreen-pip-side-by-side" height={icons.MediumSize} width={icons.MediumSize} path={icons.SIDE_BY_SIDE_ICON_PATH} />
+          <Icon
+            id="dualscreen-pip-side-by-side"
+            height={icons.MediumSize}
+            width={icons.MediumSize}
+            viewBox={`0 0 ${icons.MediumSize} ${icons.MediumSize}`}
+            path={icons.SIDE_BY_SIDE_ICON_PATH}
+          />
         </Button>
       </div>
     );
@@ -59,7 +71,13 @@ export class PipChild extends Component<PIPChildComponentProps> {
       <Button className={styles.hideContainer} onClick={this.props.hide}>
         <Fragment>
           <div className={styles.iconContainer}>
-            <Icon id="dualscreen-pip-hide" height={icons.SmallSize} width={icons.SmallSize} path={icons.HIDE_ICON_PATH} />
+            <Icon
+              id="dualscreen-pip-hide"
+              height={icons.SmallSize}
+              width={icons.SmallSize}
+              viewBox={`0 0 ${icons.SmallSize} ${icons.SmallSize}`}
+              path={icons.HIDE_ICON_PATH}
+            />
           </div>
           {Labels.Hide}
         </Fragment>

--- a/src/components/pip/pip-child.tsx
+++ b/src/components/pip/pip-child.tsx
@@ -93,7 +93,7 @@ export class PipChild extends Component<PIPChildComponentProps> {
 
     const height: number = (props.guiClientRect!.height * props.playerSizePercentage) / 100;
     const width: number = (height * 16) / 9;
-    const videoContainerStyles = {
+    const playerContainerStyles = {
       height: `${height + 'px'}`,
       width: `${width + 'px'}`
     };
@@ -101,7 +101,7 @@ export class PipChild extends Component<PIPChildComponentProps> {
     return (
       <div className={styleClass.join(' ')} ref={this.pipContainerRef}>
         {this._renderHideButton()}
-        <div className={styles.playerContainer} style={videoContainerStyles} ref={this.playerContainerRef}>
+        <div className={styles.playerContainer} style={playerContainerStyles} ref={this.playerContainerRef}>
           {this._renderInnerButtons()}
         </div>
       </div>

--- a/src/components/pip/pip-child.tsx
+++ b/src/components/pip/pip-child.tsx
@@ -40,43 +40,38 @@ export class PipChild extends Component<PIPChildComponentProps> {
     this.videoContainerRef?.current?.appendChild(player.getView());
   }
 
-  private _handleClick = (fn: Function) => (e: Event) => {
-    e.stopPropagation();
-    fn();
-  };
-
-  private _renderHoverButton() {
-    const {onSideBySideSwitch, hide, onInversePIP, playerHover, isDragging} = this.props;
-    if (!playerHover || isDragging) {
-      return null;
-    }
+  private _renderInnerButtons() {
+    const {onSideBySideSwitch, onInversePIP} = this.props;
     return (
-      <div>
-        <div className={styles.innerButtons}>
-          <Button className={styles.iconContainer} onClick={onInversePIP}>
-            <Icon id="dualscreen-pip-swap" height={icons.MediumSize} width={icons.MediumSize} path={icons.SWAP_ICON_PATH} />
-          </Button>
-          <Button className={styles.iconContainer} onClick={onSideBySideSwitch}>
-            <Icon id="dualscreen-pip-side-by-side" height={icons.MediumSize} width={icons.MediumSize} path={icons.SIDE_BY_SIDE_ICON_PATH} />
-          </Button>
-        </div>
-        <Button className={styles.hideContainer} onClick={hide}>
-          <Fragment>
-            <div className={styles.iconContainer}>
-              <Icon id="dualscreen-pip-hide" height={icons.SmallSize} width={icons.SmallSize} path={icons.HIDE_ICON_PATH} />
-            </div>
-            Hide
-          </Fragment>
+      <div className={styles.innerButtons}>
+        <Button className={styles.iconContainer} onClick={onInversePIP}>
+          <Icon id="dualscreen-pip-swap" height={icons.MediumSize} width={icons.MediumSize} path={icons.SWAP_ICON_PATH} />
+        </Button>
+        <Button className={styles.iconContainer} onClick={onSideBySideSwitch}>
+          <Icon id="dualscreen-pip-side-by-side" height={icons.MediumSize} width={icons.MediumSize} path={icons.SIDE_BY_SIDE_ICON_PATH} />
         </Button>
       </div>
+    );
+  }
+
+  private _renderHideButton() {
+    return (
+      <Button className={styles.hideContainer} onClick={this.props.hide}>
+        <Fragment>
+          <div className={styles.iconContainer}>
+            <Icon id="dualscreen-pip-hide" height={icons.SmallSize} width={icons.SmallSize} path={icons.HIDE_ICON_PATH} />
+          </div>
+          Hide
+        </Fragment>
+      </Button>
     );
   }
 
   render(props: PIPChildComponentProps) {
     const styleClass = [styles.childPlayer];
 
-    if (props.isDragging) {
-      styleClass.push(styles.dragging);
+    if (props.isDragging || !props.playerHover) {
+      styleClass.push(styles.hideControlButtons);
     }
 
     if (!props.prePlayback && props.animation) {
@@ -102,8 +97,10 @@ export class PipChild extends Component<PIPChildComponentProps> {
 
     return (
       <div className={styleClass.join(' ')} ref={this.pipContainerRef}>
-        <div className={styles.videoContainer} style={videoContainerStyles} ref={this.videoContainerRef} />
-        {this._renderHoverButton()}
+        {this._renderHideButton()}
+        <div className={styles.videoContainer} style={videoContainerStyles} ref={this.videoContainerRef}>
+          {this._renderInnerButtons()}
+        </div>
       </div>
     );
   }

--- a/src/components/pip/pip-child.tsx
+++ b/src/components/pip/pip-child.tsx
@@ -32,12 +32,12 @@ interface PIPChildComponentConnectProps {
 type PIPChildComponentProps = PIPChildComponentOwnProps & PIPChildComponentConnectProps;
 @connect(mapStateToProps, utils.bindActions(reducers.shell.actions))
 export class PipChild extends Component<PIPChildComponentProps> {
-  videoContainerRef = createRef<HTMLDivElement>();
+  playerContainerRef = createRef<HTMLDivElement>();
   pipContainerRef = createRef<HTMLDivElement>();
 
   componentDidMount() {
     const {player} = this.props;
-    this.videoContainerRef?.current?.appendChild(player.getView());
+    this.playerContainerRef?.current?.appendChild(player.getView());
   }
 
   private _renderInnerButtons() {
@@ -70,8 +70,11 @@ export class PipChild extends Component<PIPChildComponentProps> {
   render(props: PIPChildComponentProps) {
     const styleClass = [styles.childPlayer];
 
-    if (props.isDragging || !props.playerHover) {
-      styleClass.push(styles.hideControlButtons);
+    if (props.isDragging) {
+      styleClass.push(styles.dragging);
+    }
+    if (!props.playerHover) {
+      styleClass.push(styles.hovering);
     }
 
     if (!props.prePlayback && props.animation) {
@@ -98,7 +101,7 @@ export class PipChild extends Component<PIPChildComponentProps> {
     return (
       <div className={styleClass.join(' ')} ref={this.pipContainerRef}>
         {this._renderHideButton()}
-        <div className={styles.videoContainer} style={videoContainerStyles} ref={this.videoContainerRef}>
+        <div className={styles.playerContainer} style={videoContainerStyles} ref={this.playerContainerRef}>
           {this._renderInnerButtons()}
         </div>
       </div>

--- a/src/components/pip/pip.scss
+++ b/src/components/pip/pip.scss
@@ -7,13 +7,17 @@ $hideContainerGap: 5px;
 .childPlayer {
   position: relative;
 
-  &.hideControlButtons {
-    .hideContainer {
-      display: none;
-    }
+  &.hovering,
+  &.dragging {
     .innerButtons {
       display: none;
     }
+  }
+  &.hovering .hideContainer {
+    display: none;
+  }
+  &.dragging .hideContainer {
+    visibility: hidden;
   }
 
   .hideContainer {
@@ -49,7 +53,7 @@ $hideContainerGap: 5px;
     }
   }
 
-  .videoContainer {
+  .playerContainer {
     position: relative;
     border-radius: 8px;
     overflow: hidden;

--- a/src/components/pip/pip.scss
+++ b/src/components/pip/pip.scss
@@ -2,7 +2,7 @@
 @import '~styles/styles';
 
 $hide-container-height: 32px;
-$hideContainerGap: 5px;
+$hide-container-gap: 5px;
 
 .childPlayer {
   position: relative;
@@ -24,7 +24,7 @@ $hideContainerGap: 5px;
     position: relative;
     width: 66px;
     height: $hide-container-height;
-    margin-bottom: $hideContainerGap;
+    margin-bottom: $hide-container-gap;
     margin-left: auto;
 
     display: flex;
@@ -63,7 +63,6 @@ $hideContainerGap: 5px;
   .innerButtons {
     flex-direction: row-reverse;
     border-radius: 8px;
-    z-index: 1;
 
     .iconContainer {
       margin-left: 8px;

--- a/src/components/pip/pip.scss
+++ b/src/components/pip/pip.scss
@@ -7,26 +7,28 @@ $hideContainerGap: 5px;
 .childPlayer {
   position: relative;
 
-  .videoContainer {
-    border-radius: 8px;
-    overflow: hidden;
-    box-shadow: 0 0 40px 0 rgba(0, 0, 0, 0.2), 0 0 4px 0 rgba(0, 0, 0, 0.3);
+  &.hideControlButtons {
+    .hideContainer {
+      display: none;
+    }
+    .innerButtons {
+      display: none;
+    }
   }
 
   .hideContainer {
-    display: flex;
-    flex-direction: row;
-    justify-content: flex-end;
-    align-items: center;
-    padding: 8px;
-    cursor: pointer;
-
-    position: absolute;
+    position: relative;
     width: 66px;
     height: $hide-container-height;
-    right: 0px;
-    top: calc((#{$hideContainerGap + $hide-container-height}) * -1);
+    margin-bottom: $hideContainerGap;
+    margin-left: auto;
 
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+
+    cursor: pointer;
     color: #ffffff;
     font-style: normal;
     font-weight: normal;
@@ -47,9 +49,17 @@ $hideContainerGap: 5px;
     }
   }
 
+  .videoContainer {
+    position: relative;
+    border-radius: 8px;
+    overflow: hidden;
+    box-shadow: 0 0 40px 0 rgba(0, 0, 0, 0.2), 0 0 4px 0 rgba(0, 0, 0, 0.3);
+  }
+
   .innerButtons {
     flex-direction: row-reverse;
     border-radius: 8px;
+    z-index: 1;
 
     .iconContainer {
       margin-left: 8px;

--- a/src/components/side-by-side/side-by-side.tsx
+++ b/src/components/side-by-side/side-by-side.tsx
@@ -38,7 +38,13 @@ export class SideBySide extends Component<SideBySideComponentProps> {
     return (
       <div className={styles.innerButtons}>
         <Button className={styles.iconContainer} onClick={onPIPSwitch} tooltip={{label: Labels.ExpandScreen, type: 'bottom-left'}}>
-          <Icon id="dualscreen-side-by-side-pip" height={icons.MediumSize} width={icons.MediumSize} viewBox={`0 0 ${icons.MediumSize} ${icons.MediumSize}`} path={icons.SWITCH_TO_SIDE_BY_SIDE_ICON_PATH} />
+          <Icon
+            id="dualscreen-side-by-side-pip"
+            height={icons.MediumSize}
+            width={icons.MediumSize}
+            viewBox={`0 0 ${icons.MediumSize} ${icons.MediumSize}`}
+            path={icons.SWITCH_TO_SIDE_BY_SIDE_ICON_PATH}
+          />
         </Button>
       </div>
     );


### PR DESCRIPTION
Current PR fixes bug with "hide" button that currently has absolute position and overlapped top bar when PIP component had top-right or top-left position.
The changes discussed with @RoyBregman: "hide" button use relative position and located "inside" draggable container (see on attached screenshots)

For screenshots background of **playkit-interactive-area** changed to **red**

<img width="340" alt="Screen Shot 2021-06-17 at 5 00 03 PM" src="https://user-images.githubusercontent.com/51074448/122411568-872ace80-cf8d-11eb-9c30-905c762104d1.png">
<img width="271" alt="Screen Shot 2021-06-17 at 4 58 43 PM" src="https://user-images.githubusercontent.com/51074448/122411586-8a25bf00-cf8d-11eb-9893-03582fbe1738.png">
