### PR TITLE
fix(FEV-970): changing a dual-screen entry to be Unlisted triggers an error on the player

### DIFF
--- a/src/dualscreen.tsx
+++ b/src/dualscreen.tsx
@@ -332,10 +332,11 @@ export class DualScreen extends KalturaPlayer.core.BasePlugin {
         if (data && data.has(SecondaryMediaLoader.id)) {
           const secondaryMediaLoader = data.get(SecondaryMediaLoader.id);
           const entryId = secondaryMediaLoader?.response?.entries[0]?.id;
+          const ks : string = this._player.config.session.ks;
           if (!entryId) {
             this.logger.warn('Secondary entry id not found');
           } else {
-            this._secondaryKalturaPlayer.loadMedia({entryId});
+            this._secondaryKalturaPlayer.loadMedia({entryId, ks});
             this._videoSyncManager = new VideoSyncManager(this.eventManager, this.player, this._secondaryKalturaPlayer, this.logger);
             this.eventManager.listen(this._secondaryKalturaPlayer, this.player.Event.FIRST_PLAYING, () => {
               this.logger.debug('secondary player first playing - show dual mode');

--- a/src/global-types/kaltura-player/player.d.ts
+++ b/src/global-types/kaltura-player/player.d.ts
@@ -19,7 +19,7 @@ declare namespace KalturaPlayerTypes {
     paused: boolean;
     seeking: boolean;
     isOnLiveEdge: () => boolean;
-    loadMedia: (options: {entryId: string}) => void;
+    loadMedia: (options: {entryId: string, ks?: string}) => void;
     getVideoElement(): HTMLVideoElement;
     addEventListener(type: string, listener: CoreEventListener): void;
     removeEventListener: (type: string, listener: CoreEventListener) => void;


### PR DESCRIPTION
primary ks should pass to secondary ks when loading media

solves FEV-970