### PR TITLE
fix(FEC-969): an error is displayed on the player console

### DIFF
--- a/src/dualscreen.tsx
+++ b/src/dualscreen.tsx
@@ -332,7 +332,7 @@ export class DualScreen extends KalturaPlayer.core.BasePlugin {
         if (data && data.has(SecondaryMediaLoader.id)) {
           const secondaryMediaLoader = data.get(SecondaryMediaLoader.id);
           const entryId = secondaryMediaLoader?.response?.entries[0]?.id;
-          const ks : string = this._player.config.session.ks;
+          const ks: string = this._player.config.session.ks;
           if (!entryId) {
             this.logger.warn('Secondary entry id not found');
           } else {
@@ -368,6 +368,11 @@ export class DualScreen extends KalturaPlayer.core.BasePlugin {
       },
       provider: {
         partnerId: this._player.config.provider.partnerId
+      },
+      plugins: {
+        dualscreen: {
+          disable: true
+        }
       }
     };
     return KalturaPlayer.setup(secondaryPlayerConfig);


### PR DESCRIPTION
explicitly disable dualscreen plugin in the secondary.
Happens due changes in the KP which apply primary uiconf config on all players in the page.
Will be later replaced with some generic disable.