### PR TITLE
fix(FEV-974): use draggable target to define draggable area

### DIFF
--- a/src/components/drag-and-snap-manager/drag-and-snap-manager.tsx
+++ b/src/components/drag-and-snap-manager/drag-and-snap-manager.tsx
@@ -40,6 +40,7 @@ const mapStateToProps = (state: Record<string, any>) => ({
 });
 @connect(mapStateToProps)
 export class DragAndSnapManager extends Component<DragAndSnapManagerProps, DragAndSnapManagerState> {
+  private _draggableTargetRef = createRef<HTMLDivElement>();
   private _draggableItemRef = createRef<HTMLDivElement>();
   private _draggableAreaRef = createRef<HTMLDivElement>();
   private _currMousePos: {x: number; y: number} = {x: 0, y: 0};
@@ -49,7 +50,6 @@ export class DragAndSnapManager extends Component<DragAndSnapManagerProps, DragA
   };
 
   componentDidMount() {
-    this._addListeners();
     this._setRelativeStyles();
   }
 
@@ -59,13 +59,18 @@ export class DragAndSnapManager extends Component<DragAndSnapManagerProps, DragA
     eventManager.unlisten(document, DragEvents.TouchMove);
     eventManager.unlisten(document, DragEvents.MouseUp);
     eventManager.unlisten(document, DragEvents.TouchEnd);
-    eventManager.unlisten(this._draggableItemRef.current!, DragEvents.MouseDown);
-    eventManager.unlisten(this._draggableItemRef.current!, DragEvents.TouchStart);
+    eventManager.unlisten(this._draggableTargetRef.current!, DragEvents.MouseDown);
+    eventManager.unlisten(this._draggableTargetRef.current!, DragEvents.TouchStart);
   }
 
   private _renderChildComponent = (): VNode => {
     const {children} = this.props;
-    return cloneElement(children, {isDragging: this.state.isDragging});
+    return cloneElement(children, {isDragging: this.state.isDragging, setDraggableTarget: this._setDraggableTarget});
+  };
+
+  private _setDraggableTarget = (targetEl: HTMLDivElement) => {
+    this._draggableTargetRef.current = targetEl;
+    this._addListeners();
   };
 
   private _handleChangePosition = (position: Position) => {
@@ -81,11 +86,11 @@ export class DragAndSnapManager extends Component<DragAndSnapManagerProps, DragA
   };
 
   private _addListeners = () => {
-    this.props.eventManager.listen(this._draggableItemRef.current!, DragEvents.MouseDown, e => {
+    this.props.eventManager.listen(this._draggableTargetRef.current!, DragEvents.MouseDown, e => {
       this._startDrag(e, DragEvents.MouseMove, DragEvents.MouseUp);
     });
-    this.props.eventManager.listen(this._draggableItemRef.current!, DragEvents.TouchStart, e => {
-      this.props.eventManager.unlisten(this._draggableItemRef.current!, DragEvents.MouseDown);
+    this.props.eventManager.listen(this._draggableTargetRef.current!, DragEvents.TouchStart, e => {
+      this.props.eventManager.unlisten(this._draggableTargetRef.current!, DragEvents.MouseDown);
       this._startDrag(e, DragEvents.TouchMove, DragEvents.TouchEnd);
     });
   };

--- a/src/components/pip/pip-child.tsx
+++ b/src/components/pip/pip-child.tsx
@@ -45,7 +45,7 @@ export class PipChild extends Component<PIPChildComponentProps> {
   private _renderInnerButtons() {
     const {onSideBySideSwitch, onInversePIP} = this.props;
     return (
-      <Fragment>
+      <div className={styles.innerButtons}>
         <Button className={styles.iconContainer} onClick={onInversePIP} tooltip={{label: Labels.SwitchScreen, type: 'bottom-left'}}>
           <Icon
             id="dualscreen-pip-swap"
@@ -64,7 +64,7 @@ export class PipChild extends Component<PIPChildComponentProps> {
             path={icons.SIDE_BY_SIDE_ICON_PATH}
           />
         </Button>
-      </Fragment>
+      </div>
     );
   }
 
@@ -123,7 +123,7 @@ export class PipChild extends Component<PIPChildComponentProps> {
         {this._renderHideButton()}
         <div className={styles.playerWrapper}>
           <div className={styles.playerContainer} style={playerContainerStyles} ref={this.playerContainerRef} />
-          <div className={styles.innerButtons}>{this._renderInnerButtons()}</div>
+          {this._renderInnerButtons()}
         </div>
       </div>
     );

--- a/src/components/pip/pip-child.tsx
+++ b/src/components/pip/pip-child.tsx
@@ -45,7 +45,7 @@ export class PipChild extends Component<PIPChildComponentProps> {
   private _renderInnerButtons() {
     const {onSideBySideSwitch, onInversePIP} = this.props;
     return (
-      <div className={styles.buttonsWrapper}>
+      <Fragment>
         <Button className={styles.iconContainer} onClick={onInversePIP} tooltip={{label: Labels.SwitchScreen, type: 'bottom-left'}}>
           <Icon
             id="dualscreen-pip-swap"
@@ -64,7 +64,7 @@ export class PipChild extends Component<PIPChildComponentProps> {
             path={icons.SIDE_BY_SIDE_ICON_PATH}
           />
         </Button>
-      </div>
+      </Fragment>
     );
   }
 
@@ -122,10 +122,8 @@ export class PipChild extends Component<PIPChildComponentProps> {
       <div className={styleClass.join(' ')} ref={this.pipContainerRef}>
         {this._renderHideButton()}
         <div className={styles.playerWrapper}>
-          <div className={styles.playerContainer} style={playerContainerStyles} ref={this.playerContainerRef}>
-            <div className={styles.innerButtons} />
-          </div>
-          {this._renderInnerButtons()}
+          <div className={styles.playerContainer} style={playerContainerStyles} ref={this.playerContainerRef} />
+          <div className={styles.innerButtons}>{this._renderInnerButtons()}</div>
         </div>
       </div>
     );

--- a/src/components/pip/pip-child.tsx
+++ b/src/components/pip/pip-child.tsx
@@ -22,6 +22,7 @@ interface PIPChildComponentOwnProps {
   onInversePIP: () => void;
   animation: Animations;
   isDragging?: boolean;
+  setDraggableTarget?: (targetEl: HTMLDivElement) => void;
 }
 interface PIPChildComponentConnectProps {
   guiClientRect?: GuiClientRect;
@@ -37,13 +38,14 @@ export class PipChild extends Component<PIPChildComponentProps> {
 
   componentDidMount() {
     const {player} = this.props;
-    this.playerContainerRef?.current?.prepend(player.getView());
+    this.playerContainerRef.current!.prepend(player.getView());
+    this.props.setDraggableTarget!(this.playerContainerRef.current!);
   }
 
   private _renderInnerButtons() {
     const {onSideBySideSwitch, onInversePIP} = this.props;
     return (
-      <div className={styles.innerButtons}>
+      <div className={styles.buttonsWrapper}>
         <Button className={styles.iconContainer} onClick={onInversePIP} tooltip={{label: Labels.SwitchScreen, type: 'bottom-left'}}>
           <Icon
             id="dualscreen-pip-swap"
@@ -119,7 +121,10 @@ export class PipChild extends Component<PIPChildComponentProps> {
     return (
       <div className={styleClass.join(' ')} ref={this.pipContainerRef}>
         {this._renderHideButton()}
-        <div className={styles.playerContainer} style={playerContainerStyles} ref={this.playerContainerRef}>
+        <div className={styles.playerWrapper}>
+          <div className={styles.playerContainer} style={playerContainerStyles} ref={this.playerContainerRef}>
+            <div className={styles.innerButtons} />
+          </div>
           {this._renderInnerButtons()}
         </div>
       </div>

--- a/src/components/pip/pip.scss
+++ b/src/components/pip/pip.scss
@@ -9,8 +9,7 @@ $hide-container-gap: 5px;
 
   &.hovering,
   &.dragging {
-    .innerButtons,
-    .buttonsWrapper {
+    .innerButtons {
       display: none;
     }
   }
@@ -64,19 +63,19 @@ $hide-container-gap: 5px;
     }
   
     .innerButtons {
+      flex-direction: row-reverse;
       border-radius: 8px;
-    }
-  }
+      pointer-events: none;
+      * {
+        pointer-events: auto;
+      }
 
-  .buttonsWrapper {
-    position: absolute;
-    top: 8px;
-    right: 8px;
-    .iconContainer {
-      display: inline-block;
-      padding: 2px;
-      &:last-child {
-        margin-left: 8px;
+      .iconContainer {
+        display: inline-block;
+        padding: 2px;
+        &:first-child {
+          margin-left: 8px;
+        }
       }
     }
   }

--- a/src/components/pip/pip.scss
+++ b/src/components/pip/pip.scss
@@ -9,7 +9,8 @@ $hide-container-gap: 5px;
 
   &.hovering,
   &.dragging {
-    .innerButtons {
+    .innerButtons,
+    .buttonsWrapper {
       display: none;
     }
   }

--- a/src/components/pip/pip.scss
+++ b/src/components/pip/pip.scss
@@ -53,21 +53,30 @@ $hide-container-gap: 5px;
     }
   }
 
-  .playerContainer {
+  .playerWrapper {
     position: relative;
-    border-radius: 8px;
-    overflow: hidden;
-    box-shadow: 0 0 40px 0 rgba(0, 0, 0, 0.2), 0 0 4px 0 rgba(0, 0, 0, 0.3);
+
+    .playerContainer {
+      border-radius: 8px;
+      overflow: hidden;
+      box-shadow: 0 0 40px 0 rgba(0, 0, 0, 0.2), 0 0 4px 0 rgba(0, 0, 0, 0.3);
+    }
+  
+    .innerButtons {
+      border-radius: 8px;
+    }
   }
 
-  .innerButtons {
-    flex-direction: row-reverse;
-    border-radius: 8px;
-
+  .buttonsWrapper {
+    position: absolute;
+    top: 8px;
+    right: 8px;
     .iconContainer {
-      margin-left: 8px;
       display: inline-block;
       padding: 2px;
+      &:last-child {
+        margin-left: 8px;
+      }
     }
   }
 }

--- a/src/styles/_styles.scss
+++ b/src/styles/_styles.scss
@@ -16,12 +16,12 @@
   padding: 8px;
   background: linear-gradient(180deg, rgba(0, 0, 0, 0.7) 0%, rgba(0, 0, 0, 0) 100%);
   width: 100%;
-}
 
-.iconContainer {
-  &:hover {
-    background: #444444;
-    border-radius: 4px;
-    opacity: 1;
+  .iconContainer {
+    &:hover {
+      background: #444444;
+      border-radius: 4px;
+      opacity: 1;
+    }
   }
 }

--- a/src/styles/_styles.scss
+++ b/src/styles/_styles.scss
@@ -16,12 +16,12 @@
   padding: 8px;
   background: linear-gradient(180deg, rgba(0, 0, 0, 0.7) 0%, rgba(0, 0, 0, 0) 100%);
   width: 100%;
+}
 
-  .iconContainer {
-    &:hover {
-      background: #444444;
-      border-radius: 4px;
-      opacity: 1;
-    }
+.iconContainer {
+  &:hover {
+    background: #444444;
+    border-radius: 4px;
+    opacity: 1;
   }
 }


### PR DESCRIPTION
PR fixes issue with dragging area, when user can drag the child player by dragging buttons.
New property `draggableTarget` define which area should be listened on draggable events.