### PR TITLE
fix(FEV-962): responsiveness - handle small size of player

### DIFF
--- a/src/components/responsive-manager/responsive-manager.tsx
+++ b/src/components/responsive-manager/responsive-manager.tsx
@@ -23,6 +23,15 @@ const mapStateToProps = (state: Record<string, any>) => ({
 });
 @connect(mapStateToProps)
 export class ResponsiveManager extends Component<ResponsiveManagerProps> {
+  static defaultProps = {
+    onMinSize: () => {}
+  };
+  componentDidMount() {
+    const {playerSize, onMinSize} = this.props;
+    if (MIN_SIZES.includes(playerSize!)) {
+      onMinSize();
+    }
+  }
   componentDidUpdate(prevProps: ResponsiveManagerProps) {
     const {playerSize, onMinSize, onDefaultSize} = this.props;
     if (playerSize === PLAYER_SIZE.TINY) {

--- a/src/dualscreen.tsx
+++ b/src/dualscreen.tsx
@@ -226,9 +226,6 @@ export class DualScreen extends KalturaPlayer.core.BasePlugin {
         container: ReservedPresetAreas.BottomBar,
         get: () => (
           <ResponsiveManager
-            onMinSize={() => {
-              this._switchToPIPMinimized(false);
-            }}
             onDefaultSize={this._setMode}>
             <PipMinimized
               show={() => this._switchToPIP(true)}
@@ -263,9 +260,6 @@ export class DualScreen extends KalturaPlayer.core.BasePlugin {
         container: ReservedPresetAreas.BottomBar,
         get: () => (
           <ResponsiveManager
-            onMinSize={() => {
-              this._switchToPIPMinimizedInverse(false);
-            }}
             onDefaultSize={this._setMode}>
             <PipMinimized
               show={() => this._switchToPIPInverse(true)}


### PR DESCRIPTION
1) removed unnecessary `onMinSize` method for PIPMinimized and PIPMinimizedInverse layouts;
2) set default `onMinSize` property for ResponsiveManager component;
3) check player size on initial loading of ResponsiveManager component;