### PR TITLE
fix(FEV-1006): primary player wait for secondary player

### DIFF
--- a/src/dualscreen-engine-decorator.ts
+++ b/src/dualscreen-engine-decorator.ts
@@ -1,0 +1,38 @@
+// @ts-ignore
+import {core} from 'kaltura-player-js';
+import {DualScreen} from './dualscreen';
+
+const {FakeEvent, EventType} = core;
+
+// @ts-ignore
+export class DualScreenEngineDecorator implements IEngineDecorator {
+  private _plugin: DualScreen;
+  private _isActive = false;
+  private _dispatcher: Function;
+
+  constructor(engine: any, plugin: DualScreen, dispatcher: Function) {
+    this._plugin = plugin;
+    this._dispatcher = dispatcher;
+
+    plugin.eventManager.listen(plugin.player, EventType.SEEKING, () => {
+      this._isActive = true;
+    });
+    plugin.eventManager.listen(plugin.player, EventType.SEEKED, () => {
+      this._isActive = false;
+    });
+  }
+
+  get active(): boolean {
+    return this._isActive && !this._plugin.secondaryKalturaPlayer.ended;
+  }
+
+  dispatchEvent(event: FakeEvent): boolean {
+    if (event.type === EventType.SEEKED) {
+      this._plugin.eventManager.listenOnce(this._plugin.secondaryKalturaPlayer, EventType.SEEKED, () => {
+        this._dispatcher(event);
+      });
+      return true;
+    }
+    return this._dispatcher(event);
+  }
+}

--- a/src/global-types/kaltura-player/engine-decorator.d.ts
+++ b/src/global-types/kaltura-player/engine-decorator.d.ts
@@ -1,4 +1,6 @@
-interface FakeEvent {}
+interface FakeEvent {
+    type: string;
+}
 declare namespace KalturaPlayerTypes {
     export interface IEngineDecorator {
         dispatchEvent(event: FakeEvent): boolean;

--- a/src/videoSyncManager.ts
+++ b/src/videoSyncManager.ts
@@ -49,13 +49,6 @@ export class VideoSyncManager {
       this._logger.debug('syncEvents :: secondary player pause');
       this._secondaryPlayer.pause();
     });
-    this._eventManager.listen(this._secondaryPlayer, EventType.CHANGE_SOURCE_STARTED, () => {
-      // if secondary was loaded after the main has already started playing
-      if (!this._mainPlayer.paused) {
-        this._secondaryPlayer.currentTime = this._mainPlayer.currentTime;
-        this._secondaryPlayer.play();
-      }
-    });
     this._eventManager.listen(this._mainPlayer, EventType.TIME_UPDATE, () => {
       if (!this._isSyncDelay) {
         const now = Date.now();
@@ -68,9 +61,6 @@ export class VideoSyncManager {
     this._eventManager.listen(this._mainPlayer, EventType.SEEKING, () => {
       this._logger.debug(`syncEvents :: seeking main player to to ${this._mainPlayer}`);
       this._secondaryPlayer.pause();
-    });
-    this._eventManager.listen(this._mainPlayer, EventType.SEEKED, () => {
-      this._logger.debug(`syncEvents :: seeked main player to ${this._mainPlayer.currentTime}`);
       this._seekSecondaryPlayer(0);
     });
     this._eventManager.listen(this._mainPlayer, EventType.ENDED, () => {
@@ -78,7 +68,6 @@ export class VideoSyncManager {
       this._secondaryPlayer.pause();
       this._seekSecondaryPlayer(0.01);
     });
-
     this._eventManager.listen(
       this._mainPlayer,
       EventType.PLAYER_STATE_CHANGED,
@@ -176,9 +165,5 @@ export class VideoSyncManager {
     } else {
       this._secondaryPlayer.play();
     }
-  };
-
-  public destroy = () => {
-    // TODO: destroy
   };
 }


### PR DESCRIPTION
1) On initial loading primary player wait till secondary player triggered `CHANGE_SOURCE_ENDED` event (ready hook);
2) On seek primary player wait till secondary player triggered `SEEKED` event (decorator);