### PR TITLE
fix(FEV-1046): IE11 - Dual-screen plugin's layouts are broken

### DIFF
--- a/src/components/pip/pip.scss
+++ b/src/components/pip/pip.scss
@@ -6,6 +6,7 @@ $hide-container-gap: 5px;
 
 .parentPlayer {
   position: absolute;
+  left: 0;
 }
 .childPlayer {
   position: relative;

--- a/src/components/side-by-side/side-by-side.scss
+++ b/src/components/side-by-side/side-by-side.scss
@@ -5,6 +5,7 @@
   width: 100%;
   height: 100%;
   position: absolute;
+  left: 0;
   display: flex;
 }
 


### PR DESCRIPTION
small ie11 fix - when assigning position absolute - in ie11 needed to add left: 0 (other browsers have it by default)