### PR TITLE
fix(FEV-1107): changing layouts via player does not work

### DIFF
--- a/src/dualscreen.tsx
+++ b/src/dualscreen.tsx
@@ -89,6 +89,7 @@ export class DualScreen extends KalturaPlayer.core.BasePlugin implements IEngine
   reset(): void {
     this._setDefaultMode();
     this._imagePlayer.reset();
+    this._imageSyncManager?.reset();
     this._readyPromise = this._makeReadyPromise();
   }
 


### PR DESCRIPTION
other cue points changes cause the entire active cues to be sent and handled.
Therefore we need to mark view changes we already handled in previous metadata updated event so we can ignore them