### PR TITLE
fix(FEV-1120): parent and child screens cannot be switched on SBS layout

### DIFF
--- a/src/dualscreen.tsx
+++ b/src/dualscreen.tsx
@@ -290,7 +290,7 @@ export class DualScreen extends KalturaPlayer.core.BasePlugin implements IEngine
                 playerSizePercentage={this.config.childSizePercentage}
                 player={this._player}
                 hide={() => this._switchToSingleMediaInverse()}
-                onSideBySideSwitch={() => this._switchToSideBySide()}
+                onSideBySideSwitch={() => this._switchToSideBySideInverse()}
                 onInversePIP={() => this._switchToPIP(Animations.Fade)}
                 aspectRatio={this.config.childAspectRatio}
               />


### PR DESCRIPTION
When we are in the PIP inverse then pressing on SBS should change to SBS inverse

fixes FEV-1120