### PR TITLE
fix(FEV-1142): Returning to a wrong layout when using DVR for getting back to a "non-slides" point

### DIFF
--- a/src/dualscreen.tsx
+++ b/src/dualscreen.tsx
@@ -2,7 +2,7 @@ import {h} from 'preact';
 import {DualScreenConfig} from './types/DualScreenConfig';
 import {PipChild, PipParent} from './components/pip';
 import {PipMinimized} from './components/pip-minimized';
-import {Animations, Layout, PlayerType, Position, ReservedPresetAreas, StreamLayout} from './enums';
+import {Animations, Layout, PlayerType, Position, ReservedPresetAreas, ExternalLayout} from './enums';
 import {VideoSyncManager} from './video-sync-manager';
 import {ImageSyncManager, ViewChangeData} from './image-sync-manager';
 import {ResponsiveManager} from './components/responsive-manager';
@@ -23,7 +23,7 @@ export class DualScreen extends KalturaPlayer.core.BasePlugin implements IEngine
   public secondaryKalturaPlayer: KalturaPlayerTypes.Player;
   private _player: KalturaPlayerTypes.Player;
   private _layout: Layout;
-  private _streamLayout: StreamLayout | null = null;
+  private _streamLayout: ExternalLayout | null = null;
   private _pipPosition: Position = Position.BottomRight;
   private _removeActivesArr: Function[] = [];
   private _videoSyncManager?: VideoSyncManager;
@@ -485,36 +485,36 @@ export class DualScreen extends KalturaPlayer.core.BasePlugin implements IEngine
     kalturaCuePointService?.registerTypes([kalturaCuePointService.CuepointType.SLIDE, kalturaCuePointService.CuepointType.VIEW_CHANGE]);
   }
 
-  private _onSlideViewChanged = (streamLayout: StreamLayout) => {
-    if (this._streamLayout === streamLayout) {
+  private _onSlideViewChanged = (viewChange: ExternalLayout) => {
+    if (this._streamLayout === viewChange) {
       return;
     }
-    this._streamLayout = streamLayout;
+    this._streamLayout = viewChange;
     switch (this._streamLayout) {
-      case StreamLayout.Hidden:
+      case ExternalLayout.Hidden:
         this._switchToHidden();
         break;
-      case StreamLayout.SingleMedia:
+      case ExternalLayout.SingleMedia:
         if (this._layout !== Layout.SingleMedia) {
           this._switchToSingleMedia();
         }
         break;
-      case StreamLayout.PIP:
+      case ExternalLayout.PIP:
         if (this._layout !== Layout.PIP) {
           this._switchToPIP();
         }
         break;
-      case StreamLayout.PIPInverse:
+      case ExternalLayout.PIPInverse:
         if (this._layout !== Layout.PIPInverse) {
           this._switchToPIPInverse();
         }
         break;
-      case StreamLayout.SideBySide:
+      case ExternalLayout.SideBySide:
         if (this._layout !== Layout.SideBySide) {
           this._switchToSideBySide();
         }
         break;
-      case StreamLayout.SideBySideInverse:
+      case ExternalLayout.SideBySideInverse:
         if (this._layout !== Layout.SideBySideInverse) {
           this._switchToSideBySideInverse();
         }

--- a/src/dualscreen.tsx
+++ b/src/dualscreen.tsx
@@ -23,7 +23,7 @@ export class DualScreen extends KalturaPlayer.core.BasePlugin implements IEngine
   public secondaryKalturaPlayer: KalturaPlayerTypes.Player;
   private _player: KalturaPlayerTypes.Player;
   private _layout: Layout;
-  private _streamLayout: ExternalLayout | null = null;
+  private _externalLayout: ExternalLayout | null = null;
   private _pipPosition: Position = Position.BottomRight;
   private _removeActivesArr: Function[] = [];
   private _videoSyncManager?: VideoSyncManager;
@@ -179,7 +179,7 @@ export class DualScreen extends KalturaPlayer.core.BasePlugin implements IEngine
     }
     this._pipPosition = this.config.position;
     this._pipPortraitMode = false;
-    this._streamLayout = null;
+    this._externalLayout = null;
   };
 
   private _removeActives() {
@@ -465,7 +465,7 @@ export class DualScreen extends KalturaPlayer.core.BasePlugin implements IEngine
     }
 
     let originalHiddenLayout = false;
-    if (this._layout === Layout.Hidden && !this._streamLayout) {
+    if (this._layout === Layout.Hidden && !this._externalLayout) {
       originalHiddenLayout = true;
       this._setDefaultMode();
     }
@@ -486,11 +486,11 @@ export class DualScreen extends KalturaPlayer.core.BasePlugin implements IEngine
   }
 
   private _onSlideViewChanged = (viewChange: ExternalLayout) => {
-    if (this._streamLayout === viewChange) {
+    if (this._externalLayout === viewChange) {
       return;
     }
-    this._streamLayout = viewChange;
-    switch (this._streamLayout) {
+    this._externalLayout = viewChange;
+    switch (this._externalLayout) {
       case ExternalLayout.Hidden:
         this._switchToHidden();
         break;

--- a/src/dualscreen.tsx
+++ b/src/dualscreen.tsx
@@ -2,7 +2,7 @@ import {h} from 'preact';
 import {DualScreenConfig} from './types/DualScreenConfig';
 import {PipChild, PipParent} from './components/pip';
 import {PipMinimized} from './components/pip-minimized';
-import {Animations, Layout, PlayerType, Position, ReservedPresetAreas} from './enums';
+import {Animations, Layout, PlayerType, Position, ReservedPresetAreas, StreamLayout} from './enums';
 import {VideoSyncManager} from './video-sync-manager';
 import {ImageSyncManager, ViewChangeData} from './image-sync-manager';
 import {ResponsiveManager} from './components/responsive-manager';
@@ -23,6 +23,7 @@ export class DualScreen extends KalturaPlayer.core.BasePlugin implements IEngine
   public secondaryKalturaPlayer: KalturaPlayerTypes.Player;
   private _player: KalturaPlayerTypes.Player;
   private _layout: Layout;
+  private _streamLayout: StreamLayout | null = null;
   private _pipPosition: Position = Position.BottomRight;
   private _removeActivesArr: Function[] = [];
   private _videoSyncManager?: VideoSyncManager;
@@ -178,6 +179,7 @@ export class DualScreen extends KalturaPlayer.core.BasePlugin implements IEngine
     }
     this._pipPosition = this.config.position;
     this._pipPortraitMode = false;
+    this._streamLayout = null;
   };
 
   private _removeActives() {
@@ -463,7 +465,7 @@ export class DualScreen extends KalturaPlayer.core.BasePlugin implements IEngine
     }
 
     let originalHiddenLayout = false;
-    if (this._layout === Layout.Hidden) {
+    if (this._layout === Layout.Hidden && !this._streamLayout) {
       originalHiddenLayout = true;
       this._setDefaultMode();
     }
@@ -483,33 +485,36 @@ export class DualScreen extends KalturaPlayer.core.BasePlugin implements IEngine
     kalturaCuePointService?.registerTypes([kalturaCuePointService.CuepointType.SLIDE, kalturaCuePointService.CuepointType.VIEW_CHANGE]);
   }
 
-  private _onSlideViewChanged = ({playerViewModeId}: ViewChangeData, viewModeLockState: boolean) => {
-    if (viewModeLockState) {
-      this._switchToHidden();
+  private _onSlideViewChanged = (streamLayout: StreamLayout) => {
+    if (this._streamLayout === streamLayout) {
       return;
     }
-    switch (playerViewModeId) {
-      case 'parent-only':
+    this._streamLayout = streamLayout;
+    switch (this._streamLayout) {
+      case StreamLayout.Hidden:
+        this._switchToHidden();
+        break;
+      case StreamLayout.SingleMedia:
         if (this._layout !== Layout.SingleMedia) {
           this._switchToSingleMedia();
         }
         break;
-      case 'pip-parent-in-large':
+      case StreamLayout.PIP:
         if (this._layout !== Layout.PIP) {
           this._switchToPIP();
         }
         break;
-      case 'pip-parent-in-small':
+      case StreamLayout.PIPInverse:
         if (this._layout !== Layout.PIPInverse) {
           this._switchToPIPInverse();
         }
         break;
-      case 'sbs-parent-in-left':
+      case StreamLayout.SideBySide:
         if (this._layout !== Layout.SideBySide) {
           this._switchToSideBySide();
         }
         break;
-      case 'sbs-parent-in-right':
+      case StreamLayout.SideBySideInverse:
         if (this._layout !== Layout.SideBySideInverse) {
           this._switchToSideBySideInverse();
         }

--- a/src/enums/layoutEnum.ts
+++ b/src/enums/layoutEnum.ts
@@ -8,7 +8,7 @@ export enum Layout {
   Hidden = 'Hidden'
 }
 
-export enum StreamLayout {
+export enum ExternalLayout {
   Hidden = 'locked',
   SingleMedia = 'parent-only',
   PIP = 'pip-parent-in-large',

--- a/src/enums/layoutEnum.ts
+++ b/src/enums/layoutEnum.ts
@@ -7,3 +7,17 @@ export enum Layout {
   SideBySideInverse = 'SideBySideInverse',
   Hidden = 'Hidden'
 }
+
+export enum StreamLayout {
+  Hidden = 'locked',
+  SingleMedia = 'parent-only',
+  PIP = 'pip-parent-in-large',
+  PIPInverse = 'pip-parent-in-small',
+  SideBySide = 'sbs-parent-in-left',
+  SideBySideInverse = 'sbs-parent-in-right'
+}
+
+export enum ViewModeLockState {
+  Locked = 'locked',
+  Unlocked = 'unlocked'
+}

--- a/src/image-sync-manager.ts
+++ b/src/image-sync-manager.ts
@@ -67,7 +67,7 @@ export class ImageSyncManager {
   private _onTimedMetadata = () => {
     // TODO: use single "metadata" TextTrack once cue-point manager become use it
     const activeCuePoints: Array<Cue> = Array.from(this._mainPlayer.cuePointManager.getActiveCuePoints());
-    const {activeSlide, streamLayout} = activeCuePoints.reduce<{activeSlide: string | null; streamLayout: ExternalLayout | null}>(
+    const {activeSlide, externalLayout} = activeCuePoints.reduce<{activeSlide: string | null; externalLayout: ExternalLayout | null}>(
       (acc, cue) => {
         if (cue.value?.data?.cuePointType === this._kalturaCuePointService.KalturaCuePointType.THUMB) {
           return {...acc, activeSlide: cue.value!.data.id};
@@ -75,21 +75,21 @@ export class ImageSyncManager {
         if (cue.value?.data?.cuePointType === this._kalturaCuePointService.KalturaCuePointType.CODE) {
           const {playerViewModeId, viewModeLockState} = cue.value!.data.partnerData;
           if (playerViewModeId) {
-            return {...acc, streamLayout: viewModeLockState === ViewModeLockState.Locked ? ExternalLayout.Hidden : playerViewModeId};
+            return {...acc, externalLayout: viewModeLockState === ViewModeLockState.Locked ? ExternalLayout.Hidden : playerViewModeId};
           }
         }
         return acc;
       },
       {
         activeSlide: null,
-        streamLayout: null
+        externalLayout: null
       }
     );
 
-    if (streamLayout) {
-      this._onSlideViewChanged(streamLayout);
+    if (externalLayout) {
+      this._onSlideViewChanged(externalLayout);
     }
-    if (streamLayout !== ExternalLayout.Hidden) {
+    if (externalLayout !== ExternalLayout.Hidden) {
       this._imagePlayer.setActive(activeSlide);
     }
   };


### PR DESCRIPTION
1) use `_streamLayout` property to keep current stream layout;
2) reduce iterations thru `activeCuePoints` array;
3) use enums for stream layout changes;