### PR TITLE
fix(FEV-1132):  Player breaks when there is no KS and dual plugin is configured

### DIFF
--- a/src/dualscreen.tsx
+++ b/src/dualscreen.tsx
@@ -84,11 +84,7 @@ export class DualScreen extends KalturaPlayer.core.BasePlugin implements IEngine
 
   loadMedia(): void {
     const kalturaCuePointService: any = this._player.getService('kalturaCuepoints');
-    setTimeout(() => {
-      // TODO: remove timeout once secondary media id will be included in initial player call
-      // currently timeout pospone API call to use KS from config.session.ks
-      this._getSecondaryMedia();
-    });
+    this._getSecondaryMedia();
     if (kalturaCuePointService) {
       this._getThumbs(kalturaCuePointService);
     } else {
@@ -523,7 +519,7 @@ export class DualScreen extends KalturaPlayer.core.BasePlugin implements IEngine
 
   private _getSecondaryMedia() {
     this._player.provider
-      .doRequest([{loader: SecondaryMediaLoader, params: {parentEntryId: this._player.sources.id, ks: this._player.config.session?.ks}}])
+      .doRequest([{loader: SecondaryMediaLoader, params: {parentEntryId: this._player.sources.id}}])
       .then((data: Map<string, any>) => {
         if (data && data.has(SecondaryMediaLoader.id)) {
           const secondaryMediaLoader = data.get(SecondaryMediaLoader.id);
@@ -555,7 +551,6 @@ export class DualScreen extends KalturaPlayer.core.BasePlugin implements IEngine
       })
       .catch((e: any) => {
         this.logger.error(e);
-        this._resolveReadyPromise();
       });
   }
 

--- a/src/dualscreen.tsx
+++ b/src/dualscreen.tsx
@@ -551,6 +551,7 @@ export class DualScreen extends KalturaPlayer.core.BasePlugin implements IEngine
       })
       .catch((e: any) => {
         this.logger.error(e);
+        this._resolveReadyPromise();
       });
   }
 

--- a/src/dualscreen.tsx
+++ b/src/dualscreen.tsx
@@ -84,7 +84,11 @@ export class DualScreen extends KalturaPlayer.core.BasePlugin implements IEngine
 
   loadMedia(): void {
     const kalturaCuePointService: any = this._player.getService('kalturaCuepoints');
-    this._getSecondaryMedia();
+    setTimeout(() => {
+      // TODO: remove timeout once secondary media id will be included in initial player call
+      // currently timeout pospone API call to use KS from config.session.ks
+      this._getSecondaryMedia();
+    });
     if (kalturaCuePointService) {
       this._getThumbs(kalturaCuePointService);
     } else {
@@ -519,7 +523,7 @@ export class DualScreen extends KalturaPlayer.core.BasePlugin implements IEngine
 
   private _getSecondaryMedia() {
     this._player.provider
-      .doRequest([{loader: SecondaryMediaLoader, params: {parentEntryId: this._player.sources.id}}])
+      .doRequest([{loader: SecondaryMediaLoader, params: {parentEntryId: this._player.sources.id, ks: this._player.config.session?.ks}}])
       .then((data: Map<string, any>) => {
         if (data && data.has(SecondaryMediaLoader.id)) {
           const secondaryMediaLoader = data.get(SecondaryMediaLoader.id);
@@ -551,6 +555,7 @@ export class DualScreen extends KalturaPlayer.core.BasePlugin implements IEngine
       })
       .catch((e: any) => {
         this.logger.error(e);
+        this._resolveReadyPromise();
       });
   }
 

--- a/src/providers/secondary-media-loader.ts
+++ b/src/providers/secondary-media-loader.ts
@@ -2,6 +2,10 @@ import ILoader = KalturaPlayerTypes.ILoader;
 
 const {RequestBuilder, ResponseTypes} = KalturaPlayer.providers;
 
+interface SecondaryMediaLoaderParams {
+  parentEntryId: string;
+}
+
 export class SecondaryMediaLoader implements ILoader {
   _parentEntryId: string = '';
   _requests: any[] = [];
@@ -17,7 +21,7 @@ export class SecondaryMediaLoader implements ILoader {
    * @constructor
    * @param {Object} params loader params
    */
-  constructor(params: any) {
+  constructor(params: SecondaryMediaLoaderParams) {
     this._parentEntryId = params.parentEntryId;
     const headers: Map<string, string> = new Map();
     const request = new RequestBuilder(headers);

--- a/src/providers/secondary-media-loader.ts
+++ b/src/providers/secondary-media-loader.ts
@@ -2,11 +2,6 @@ import ILoader = KalturaPlayerTypes.ILoader;
 
 const {RequestBuilder, ResponseTypes} = KalturaPlayer.providers;
 
-interface SecondaryMediaLoaderParams {
-  parentEntryId: string;
-  ks: string;
-}
-
 export class SecondaryMediaLoader implements ILoader {
   _parentEntryId: string = '';
   _requests: any[] = [];
@@ -22,7 +17,7 @@ export class SecondaryMediaLoader implements ILoader {
    * @constructor
    * @param {Object} params loader params
    */
-  constructor(params: SecondaryMediaLoaderParams) {
+  constructor(params: any) {
     this._parentEntryId = params.parentEntryId;
     const headers: Map<string, string> = new Map();
     const request = new RequestBuilder(headers);
@@ -40,9 +35,6 @@ export class SecondaryMediaLoader implements ILoader {
         fields: 'id'
       }
     };
-    if (params.ks) {
-      request.params.ks = params.ks;
-    }
     this.requests.push(request);
   }
 

--- a/src/providers/secondary-media-loader.ts
+++ b/src/providers/secondary-media-loader.ts
@@ -2,6 +2,11 @@ import ILoader = KalturaPlayerTypes.ILoader;
 
 const {RequestBuilder, ResponseTypes} = KalturaPlayer.providers;
 
+interface SecondaryMediaLoaderParams {
+  parentEntryId: string;
+  ks: string;
+}
+
 export class SecondaryMediaLoader implements ILoader {
   _parentEntryId: string = '';
   _requests: any[] = [];
@@ -17,7 +22,7 @@ export class SecondaryMediaLoader implements ILoader {
    * @constructor
    * @param {Object} params loader params
    */
-  constructor(params: any) {
+  constructor(params: SecondaryMediaLoaderParams) {
     this._parentEntryId = params.parentEntryId;
     const headers: Map<string, string> = new Map();
     const request = new RequestBuilder(headers);
@@ -35,6 +40,9 @@ export class SecondaryMediaLoader implements ILoader {
         fields: 'id'
       }
     };
+    if (params.ks) {
+      request.params.ks = params.ks;
+    }
     this.requests.push(request);
   }
 


### PR DESCRIPTION
1) use KS from `player.cofig.session.ks` for getSecondaryMedia API call;
2) restore player if getSecondaryMedia API call failed;