### PR TITLE
fix(FEV-1154): loadMedia for secondary screen transform anonymous user to non-anonymous

### DIFF
--- a/src/dualscreen.tsx
+++ b/src/dualscreen.tsx
@@ -558,7 +558,7 @@ export class DualScreen extends KalturaPlayer.core.BasePlugin implements IEngine
               this._setDefaultMode();
               this._setMode();
             });
-            this.secondaryKalturaPlayer.loadMedia({entryId, ks: this._player.config.session.ks});
+            this.secondaryKalturaPlayer.loadMedia({entryId, ks: this.player.config.session.isAnonymous ? '' : this.player.config.session.ks});
           } else {
             this.logger.warn('Secondary entry id not found');
             // subscribe on timed metadata events for image player

--- a/src/providers/secondary-media-loader.ts
+++ b/src/providers/secondary-media-loader.ts
@@ -4,7 +4,6 @@ const {RequestBuilder, ResponseTypes} = KalturaPlayer.providers;
 
 interface SecondaryMediaLoaderParams {
   parentEntryId: string;
-  ks: string;
 }
 
 export class SecondaryMediaLoader implements ILoader {
@@ -38,8 +37,7 @@ export class SecondaryMediaLoader implements ILoader {
       responseProfile: {
         type: INCLUDE_FIELDS,
         fields: 'id'
-      },
-      ks: params.ks
+      }
     };
     this.requests.push(request);
   }

--- a/src/providers/secondary-media-loader.ts
+++ b/src/providers/secondary-media-loader.ts
@@ -4,6 +4,7 @@ const {RequestBuilder, ResponseTypes} = KalturaPlayer.providers;
 
 interface SecondaryMediaLoaderParams {
   parentEntryId: string;
+  ks: string;
 }
 
 export class SecondaryMediaLoader implements ILoader {
@@ -37,7 +38,8 @@ export class SecondaryMediaLoader implements ILoader {
       responseProfile: {
         type: INCLUDE_FIELDS,
         fields: 'id'
-      }
+      },
+      ks: params.ks
     };
     this.requests.push(request);
   }


### PR DESCRIPTION
**issue:**
potential of making an anonymous user to non-anonymous user when loadMedia is being executed of secondScreen.

**root cause:**
passing player.config.session.ks (non-anonymous ks).

**solution:**
passing player.config.session.ks only when isAnonymous is false.

Solves [FEV-1158](https://kaltura.atlassian.net/browse/FEV-1154)
Related to [FEC-11696](https://kaltura.atlassian.net/browse/FEC-11696)