### PR TITLE
feat(FEC-11761): expose stream timed metadata - phase 2

### DIFF
--- a/src/image-sync-manager.ts
+++ b/src/image-sync-manager.ts
@@ -58,11 +58,11 @@ export class ImageSyncManager {
     const {cues: activeCuePoints} = payload;
     const {activeSlide, externalLayout} = activeCuePoints.reduce<{activeSlide: string | null; externalLayout: ExternalLayout | null}>(
       (acc, cue) => {
-        if (cue.metadata?.data?.cuePointType === this._kalturaCuePointService.KalturaCuePointType.THUMB) {
+        if (cue.metadata?.cuePointType === this._kalturaCuePointService.KalturaCuePointType.THUMB) {
           return {...acc, activeSlide: cue.id};
         }
-        if (cue.metadata?.data?.cuePointType === this._kalturaCuePointService.KalturaCuePointType.CODE) {
-          const {playerViewModeId, viewModeLockState} = cue.metadata!.data.partnerData;
+        if (cue.metadata?.cuePointType === this._kalturaCuePointService.KalturaCuePointType.CODE) {
+          const {playerViewModeId, viewModeLockState} = cue.metadata!.partnerData;
           if (playerViewModeId) {
             return {...acc, externalLayout: viewModeLockState === ViewModeLockState.Locked ? ExternalLayout.Hidden : playerViewModeId};
           }
@@ -85,13 +85,10 @@ export class ImageSyncManager {
 
   private _onTimedMetadataAdded = ({payload}: TimedMetadata) => {
     const slides = payload.cues.map(cue => {
-      if (
-        cue?.metadata?.key === cuepoint.CUE_POINT_KEY &&
-        cue.metadata?.data?.cuePointType === this._kalturaCuePointService.KalturaCuePointType.THUMB
-      ) {
+      if (cue?.type === CuePoint.TYPE.CUE_POINT && cue.metadata?.cuePointType === this._kalturaCuePointService.KalturaCuePointType.THUMB) {
         this._imagePlayer.addImage({
           id: cue?.id,
-          imageUrl: cue.metadata!.data.assetUrl,
+          imageUrl: cue.metadata!.assetUrl,
           portrait: false,
           loading: false,
           loaded: false

--- a/src/image-sync-manager.ts
+++ b/src/image-sync-manager.ts
@@ -54,7 +54,6 @@ export class ImageSyncManager {
   };
 
   private _onTimedMetadataChange = ({payload}: TimedMetadata) => {
-    // TODO: use single "metadata" TextTrack once cue-point manager become use it
     const {cues: activeCuePoints} = payload;
     const {activeSlide, externalLayout} = activeCuePoints.reduce<{activeSlide: string | null; externalLayout: ExternalLayout | null}>(
       (acc, cue) => {

--- a/src/image-sync-manager.ts
+++ b/src/image-sync-manager.ts
@@ -3,11 +3,11 @@ import {cuepoint, core} from 'kaltura-player-js';
 import {ExternalLayout, ViewModeLockState} from './enums';
 import {ImagePlayer} from './image-player';
 
-const {CuePoint} = core;
+const {TimedMetadata} = core;
 
-interface TimedMetadata {
+interface TimedMetadataEvent {
   payload: {
-    cues: Array<typeof CuePoint>;
+    cues: Array<typeof TimedMetadata>;
   };
 }
 
@@ -53,7 +53,7 @@ export class ImageSyncManager {
     this._imagePlayer.preLoadImages();
   };
 
-  private _onTimedMetadataChange = ({payload}: TimedMetadata) => {
+  private _onTimedMetadataChange = ({payload}: TimedMetadataEvent) => {
     const {cues: activeCuePoints} = payload;
     const {activeSlide, externalLayout} = activeCuePoints.reduce<{activeSlide: string | null; externalLayout: ExternalLayout | null}>(
       (acc, cue) => {
@@ -82,9 +82,9 @@ export class ImageSyncManager {
     }
   };
 
-  private _onTimedMetadataAdded = ({payload}: TimedMetadata) => {
+  private _onTimedMetadataAdded = ({payload}: TimedMetadataEvent) => {
     const slides = payload.cues.map(cue => {
-      if (cue?.type === CuePoint.TYPE.CUE_POINT && cue.metadata?.cuePointType === this._kalturaCuePointService.KalturaCuePointType.THUMB) {
+      if (cue?.type === TimedMetadata.TYPE.CUE_POINT && cue.metadata?.cuePointType === this._kalturaCuePointService.KalturaCuePointType.THUMB) {
         this._imagePlayer.addImage({
           id: cue?.id,
           imageUrl: cue.metadata!.assetUrl,

--- a/test/src/image-sync-manager.spec.js
+++ b/test/src/image-sync-manager.spec.js
@@ -1,6 +1,6 @@
 import {setup} from 'kaltura-player-js';
 import * as TestUtils from './utils/test-utils';
-import {core, cuepoint} from 'kaltura-player-js';
+import {core} from 'kaltura-player-js';
 const {EventType} = core;
 
 describe('KDualscreenPlugin', function () {
@@ -73,7 +73,6 @@ describe('KDualscreenPlugin', function () {
 
     it('should handle TIMED_METADATA event', done => {
       player.addEventListener(EventType.TIMED_METADATA, ({payload}) => {
-        expect(payload.cues[0].track.label).to.eql(cuepoint.CUE_POINTS_TEXT_TRACK);
         expect(payload.cues[0].value.data.id).to.eql('test_id');
         expect(payload.cues[0].value.data.assetUrl).to.eql('test_url');
         expect(payload.cues[0].startTime).to.eql(1);


### PR DESCRIPTION
use `CuePoint` from `TIMED_METADATA_CHANGE` instead of `VttCue` from `TIMED_METADATA`

Depends on https://github.com/kaltura/kaltura-player-js/pull/512