### PR TITLE
fix(FEV-1165): Child is displayed too low on the player - it's being cut by the progress bar

### DIFF
--- a/src/components/drag-and-snap-manager/drag-and-snap-manager.scss
+++ b/src/components/drag-and-snap-manager/drag-and-snap-manager.scss
@@ -2,6 +2,8 @@
 
 .draggableArea {
   position: absolute;
+  left: 0;
+  top: 0;
   width: 100%;
   height: 100%;
   pointer-events: none;


### PR DESCRIPTION
fixed styles for "draaggbe-area" container to prevent style inheritance from KMS