### PR TITLE
fix(FEV-1267): Navigating back in the scrubber to a point where dual screen is not triggered will cause the video to play with black screen 

### DIFF
--- a/src/dualscreen.tsx
+++ b/src/dualscreen.tsx
@@ -73,16 +73,15 @@ export class DualScreen extends KalturaPlayer.core.BasePlugin implements IEngine
 
   private _removeSettingsComponent = () => {
     if (!this._undoRemoveSettings) {
-      const removeSettings =
-          {
-            presets: PRESETS,
-            container: ReservedPresetAreas.BottomBarRightControls,
-            get: KalturaPlayer.ui.components.Remove,
-            replaceComponent: KalturaPlayer.ui.components.Settings.displayName
-          }
+      const removeSettings = {
+        presets: PRESETS,
+        container: ReservedPresetAreas.BottomBarRightControls,
+        get: KalturaPlayer.ui.components.Remove,
+        replaceComponent: KalturaPlayer.ui.components.Settings.displayName
+      };
       this._undoRemoveSettings = this._player.ui.addComponent(removeSettings);
     }
-  }
+  };
 
   loadMedia(): void {
     this._addBindings();
@@ -201,6 +200,7 @@ export class DualScreen extends KalturaPlayer.core.BasePlugin implements IEngine
       value();
     });
     this._removeActivesArr = [];
+    this._originalVideoElementParent!.appendChild(this._player.getVideoElement());
   }
 
   private _setPipPosition = (position: Position) => {
@@ -235,9 +235,6 @@ export class DualScreen extends KalturaPlayer.core.BasePlugin implements IEngine
         get: () => <PipParent animation={parentAnimation} player={this._player} />
       })
     );
-    this._removeActivesArr.push(() => {
-      this._originalVideoElementParent!.appendChild(this._player.getVideoElement());
-    });
     this._removeActivesArr.push(
       this._player.ui.addComponent({
         label: 'kaltura-dual-screen-pip',
@@ -291,9 +288,6 @@ export class DualScreen extends KalturaPlayer.core.BasePlugin implements IEngine
         get: () => <PipParent animation={parentAnimation} player={this._getSecondaryPlayer()} />
       })
     );
-    this._removeActivesArr.push(() => {
-      this._originalVideoElementParent!.appendChild(this._player.getVideoElement());
-    });
     this._removeActivesArr.push(
       this._player.ui.addComponent({
         label: 'kaltura-dual-screen-pip',
@@ -314,13 +308,9 @@ export class DualScreen extends KalturaPlayer.core.BasePlugin implements IEngine
                 animation={Animations.Fade}
                 playerSizePercentage={this.config.childSizePercentage}
                 player={this._player}
-                hide={(byKeyboard: boolean) =>
-                  this._switchToSingleMediaInverse(Animations.None, getValueOrUndefined(byKeyboard, ButtonsEnum.Show))
-                }
+                hide={(byKeyboard: boolean) => this._switchToSingleMediaInverse(Animations.None, getValueOrUndefined(byKeyboard, ButtonsEnum.Show))}
                 onSideBySideSwitch={(byKeyboard: boolean) => this._switchToSideBySideInverse(byKeyboard)}
-                onInversePIP={(byKeyboard: boolean) =>
-                  this._switchToPIP(Animations.Fade, getValueOrUndefined(byKeyboard, ButtonsEnum.SwitchScreen))
-                }
+                onInversePIP={(byKeyboard: boolean) => this._switchToPIP(Animations.Fade, getValueOrUndefined(byKeyboard, ButtonsEnum.SwitchScreen))}
                 aspectRatio={this.config.childAspectRatio}
                 focusOnButton={focusOnButton}
               />
@@ -416,10 +406,6 @@ export class DualScreen extends KalturaPlayer.core.BasePlugin implements IEngine
     setSubtitlesOnTop(true);
     this._removeActives();
 
-    this._removeActivesArr.push(() => {
-      this._originalVideoElementParent!.appendChild(this._player.getVideoElement());
-    });
-
     const leftSideProps = {
       player: this._player,
       onExpand: (byKeyboard: boolean) => this._switchToPIP(Animations.ScaleRight, getValueOrUndefined(byKeyboard, ButtonsEnum.SideBySide)),
@@ -456,14 +442,9 @@ export class DualScreen extends KalturaPlayer.core.BasePlugin implements IEngine
     setSubtitlesOnTop(true);
     this._removeActives();
 
-    this._removeActivesArr.push(() => {
-      this._originalVideoElementParent!.appendChild(this._player.getVideoElement());
-    });
-
     const leftSideProps = {
       player: this._getSecondaryPlayer(),
-      onExpand: (byKeyboard: boolean) =>
-        this._switchToPIPInverse(Animations.ScaleRight, getValueOrUndefined(byKeyboard, ButtonsEnum.SideBySide)),
+      onExpand: (byKeyboard: boolean) => this._switchToPIPInverse(Animations.ScaleRight, getValueOrUndefined(byKeyboard, ButtonsEnum.SideBySide)),
       focusOnButton
     };
     const rightSideProps = {


### PR DESCRIPTION
apply player node in original element on layout change