### PR TITLE
fix(FEV-1295): Clicking on another entry in the playlist before the playlist start to play will make the playlist disappear

### DIFF
--- a/src/dualscreen.tsx
+++ b/src/dualscreen.tsx
@@ -201,7 +201,9 @@ export class DualScreen extends KalturaPlayer.core.BasePlugin implements IEngine
       value();
     });
     this._removeActivesArr = [];
-    this._originalVideoElementParent!.appendChild(this._player.getVideoElement());
+    if (this._originalVideoElementParent) {
+      this._originalVideoElementParent.appendChild(this._player.getVideoElement());
+    }
   }
 
   private _setPipPosition = (position: Position) => {


### PR DESCRIPTION
check if original Video Element exist