### PR TITLE
fix(FEV-1387): on dual screen with side by side layout when the kitchen sink is open the buttons of the dual screen are above the kitchen sink

### DIFF
--- a/src/components/side-by-side/side-by-side.scss
+++ b/src/components/side-by-side/side-by-side.scss
@@ -66,3 +66,8 @@
     opacity: 1;
   }
 }
+
+:global(.has-dual-screen-plugin-overlay.playkit-hover .playkit-side-panel) {
+  // prevent displaying innerButtons over playkit-side-panel
+  z-index: 1;
+}

--- a/src/components/side-by-side/side-by-side.tsx
+++ b/src/components/side-by-side/side-by-side.tsx
@@ -30,7 +30,7 @@ export class SideBySide extends Component<SideBySideComponentProps> {
   componentDidMount() {
     const videoElement = this.props.player.getVideoElement();
     videoElement.tabIndex = -1;
-    this.ref.current.appendChild(videoElement);
+    this.ref.current.prepend(videoElement);
   }
 
   private _renderHoverButton() {


### PR DESCRIPTION
prevent apply SbS buttons over side-panels