### PR TITLE
fix(FEV-956): while dragging, the mouse cursor should be changed to 'hand' icon

### DIFF
--- a/src/components/drag-and-snap-manager/drag-and-snap-manager.scss
+++ b/src/components/drag-and-snap-manager/drag-and-snap-manager.scss
@@ -12,7 +12,7 @@
   position: absolute;
   pointer-events: auto;
   &.dragging {
-    cursor: move;
+    cursor: grabbing;
   }
   &:not(.dragging) {
     transition: top $animation-duration ease-in, right $animation-duration ease-in, bottom $animation-duration ease-in;


### PR DESCRIPTION
**the issue:**
while dragging the pip player, the mouse cursor is currently changed to "move" icon (4 arrows)- it should be "hand" icon.

**solution:**
change the cursor value of dragging from "move" to "grabbing".

Solves [FEV-956](https://kaltura.atlassian.net/browse/FEV-956)