### PR TITLE
fix(FEV-1125): when clicking on first slide in navigation the dual screen blinks

### DIFF
--- a/src/dualscreen-engine-decorator.ts
+++ b/src/dualscreen-engine-decorator.ts
@@ -16,7 +16,7 @@ export class DualScreenEngineDecorator implements IEngineDecorator {
 
     plugin.eventManager.listen(plugin.player, EventType.SEEKING, () => {
       // activate decorator only if secondary entry is media, so decorator can handle SEEKED event from secondary player
-      this._isActive = !!this._plugin.secondaryKalturaPlayer.src;
+      this._isActive = !!this._plugin.secondaryKalturaPlayer?.src;
     });
     plugin.eventManager.listen(plugin.player, EventType.SEEKED, () => {
       this._isActive = false;

--- a/src/image-sync-manager.ts
+++ b/src/image-sync-manager.ts
@@ -77,7 +77,9 @@ export class ImageSyncManager {
     if (externalLayout) {
       this._onSlideViewChanged(externalLayout);
     }
-    this._imagePlayer.setActive(externalLayout === ExternalLayout.Hidden ? null : activeSlide);
+    if (activeSlide) {
+      this._imagePlayer.setActive(externalLayout === ExternalLayout.Hidden ? null : activeSlide);
+    }
   };
 
   private _onTimedMetadataAdded = ({payload}: TimedMetadataEvent) => {


### PR DESCRIPTION
**the issue:**
when streaming live video and uploading slides, clicking on the first slide makes the dual screen to "blink" (disappears and appears again). note that this issue is intermittent.

**solution:**
invoke `setActive` when `activeSlide` is not null.

Solves [FEV-1125](https://kaltura.atlassian.net/browse/FEV-1125)