### PR TITLE
feat(FEV-1612): the ratio of the floating screen should fit the video itself

### DIFF
--- a/src/components/pip-minimized/pip-minimized.scss
+++ b/src/components/pip-minimized/pip-minimized.scss
@@ -8,6 +8,7 @@ $show-container-gap: 5px;
   @include hideImagePlayer;
   video {
     position: relative;
+    object-fit: cover;
   }
   position: absolute;
   top: 0;

--- a/src/components/pip/pip-child.tsx
+++ b/src/components/pip/pip-child.tsx
@@ -149,7 +149,7 @@ export class PipChild extends Component<PIPChildComponentProps> {
     const width: number = (height * props.aspectRatio.width) / props.aspectRatio.height;
     const playerContainerStyles = {
       height: `${props.portrait ? width : height}px`,
-      width: `${props.portrait ? height : width}px`
+      width: 'auto'
     };
 
     return (

--- a/src/image-player/image-player.scss
+++ b/src/image-player/image-player.scss
@@ -5,7 +5,7 @@
     img {
       width:100%;
       height:100%;
-      object-fit: contain;
+      object-fit: cover;
       position: relative;
       top: 0px;
       left: 0px;


### PR DESCRIPTION
**Description of Changes:**
- pip screen should have an auto width, only the height should be calculated
- handle when pip is minimized- stretch the video/image to fill the player

Solves [FEV-1612](https://kaltura.atlassian.net/browse/FEV-1612)