### PR TITLE
fix(FEV-1386): Navigation panel is rendered 'alongSide' when set to 'over' when dual-screen plugin is active

### DIFF
--- a/src/components/pip/pip-parent.tsx
+++ b/src/components/pip/pip-parent.tsx
@@ -4,8 +4,6 @@ import {Animations} from '../../enums';
 const {connect} = KalturaPlayer.ui.redux;
 
 const mapStateToProps = (state: Record<string, any>) => ({
-  playerHeight: state.shell.guiClientRect.height,
-  playerWidth: state.shell.guiClientRect.width,
   prePlayback: state.engine.prePlayback
 });
 
@@ -14,8 +12,6 @@ interface PIPParentComponentOwnProps {
   animation: Animations;
 }
 interface PIPParentComponentConnectProps {
-  playerHeight?: number;
-  playerWidth?: number;
   prePlayback?: boolean;
 }
 

--- a/src/components/pip/pip-parent.tsx
+++ b/src/components/pip/pip-parent.tsx
@@ -46,11 +46,6 @@ export class PipParent extends Component<PIPParentComponentProps> {
       }
     }
 
-    const videoContainerStyles = {
-      height: `${props.playerHeight + 'px'}`,
-      width: `${props.playerWidth + 'px'}`
-    };
-
-    return <div className={styleClass.join(' ')} style={videoContainerStyles} ref={this.videoContainerRef} />;
+    return <div className={styleClass.join(' ')}  ref={this.videoContainerRef} />;
   }
 }

--- a/src/components/pip/pip.scss
+++ b/src/components/pip/pip.scss
@@ -5,6 +5,8 @@ $hide-container-height: 32px;
 $hide-container-gap: 5px;
 
 .parentPlayer {
+  width: 100%;
+  height: 100%;
   position: absolute;
   left: 0;
   @include hideImagePlayer;


### PR DESCRIPTION
### Description of the Changes

solves: FEV-1386

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated