### PR TITLE
fix(FEV-1612): fix safari issue

### DIFF
--- a/src/components/pip/pip-child.tsx
+++ b/src/components/pip/pip-child.tsx
@@ -149,7 +149,7 @@ export class PipChild extends Component<PIPChildComponentProps> {
     const width: number = (height * props.aspectRatio.width) / props.aspectRatio.height;
     const playerContainerStyles = {
       height: `${props.portrait ? width : height}px`,
-      width: 'auto'
+      width: `${props.portrait ? height : width}px`
     };
 
     return (

--- a/src/components/pip/pip.scss
+++ b/src/components/pip/pip.scss
@@ -13,6 +13,7 @@ $hide-container-gap: 5px;
   position: relative;
   video {
     position: relative;
+    object-fit: cover;
   }
   @include hideImagePlayer;
 


### PR DESCRIPTION
**Description of the issue:**
following merging [PR](https://github.com/kaltura/playkit-js-dual-screen/pull/85), QA found that there is an issue in the behavior of the child player in Safari (works fine in Chrome).
seems like `width: auto` is not a good solution for Safari as it stretches the entire child container over the full width of the player.

**solution:**
I have rolled back the previous change of the width and applied `object-fit: cover` to the child player instead.

Related to [FEV-1612](https://kaltura.atlassian.net/browse/FEV-1612)

[FEV-1612]: https://kaltura.atlassian.net/browse/FEV-1612