### PR TITLE
fix(FEV-1638): dualscreen plugin is causing the player to stuck on loading spinner

### DIFF
--- a/src/dualscreen.tsx
+++ b/src/dualscreen.tsx
@@ -565,6 +565,10 @@ export class DualScreen extends KalturaPlayer.core.BasePlugin implements IEngine
             this._resolveReadyPromise();
           }
         }
+        else {
+          this.logger.warn('SecondaryMediaLoader does not exist');
+          this._resolveReadyPromise();
+        }
       })
       .catch((e: any) => {
         this.logger.error(e);


### PR DESCRIPTION
**the issue:**
promise of dualscreen is stuck in pending when SecondaryMediaLoader does not exist, which is causing the player to stuck in spinning.

**solution:**
resolve promise in case there is an issue with the SecondaryMediaLoader.

Solves [FEV-1638](https://kaltura.atlassian.net/browse/FEV-1638)

[FEV-1638]: https://kaltura.atlassian.net/browse/FEV-1638