### PR TITLE
fix(FEV-1612): the ratio of the dualscreen should adjust to its content

### DIFF
--- a/src/components/pip/pip-child.tsx
+++ b/src/components/pip/pip-child.tsx
@@ -148,8 +148,7 @@ export class PipChild extends Component<PIPChildComponentProps> {
     const height: number = (props.playerHeight! * props.playerSizePercentage) / 100;
     const width: number = (height * props.aspectRatio.width) / props.aspectRatio.height;
     const playerContainerStyles = {
-      height: `${props.portrait ? width : height}px`,
-      width: `${props.portrait ? height : width}px`
+      height: `${props.portrait ? width : height}px`
     };
 
     return (

--- a/src/components/pip/pip.scss
+++ b/src/components/pip/pip.scss
@@ -14,6 +14,7 @@ $hide-container-gap: 5px;
   video {
     position: relative;
     object-fit: cover;
+    width: auto;
   }
   @include hideImagePlayer;
 

--- a/src/image-player/image-player.scss
+++ b/src/image-player/image-player.scss
@@ -4,7 +4,7 @@
     height:100%;
     background: #000000;
     img {
-      width:100%;
+      width:auto;
       height:100%;
       object-fit: cover;
       position: relative;


### PR DESCRIPTION
**Description of Changes:**
- pip screen should have an auto width, only the height should be calculated
- handle when pip is minimized- stretch the video/image to fill the player

Solves [FEV-1612](https://kaltura.atlassian.net/browse/FEV-1612)

[FEV-1612]: https://kaltura.atlassian.net/browse/FEV-1612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ