### PR TITLE
fix(FEV-1646): minimized dual screen with bad ratio content doesn't fill the entire container

### DIFF
--- a/src/components/pip-minimized/pip-minimized.scss
+++ b/src/components/pip-minimized/pip-minimized.scss
@@ -9,6 +9,7 @@ $show-container-gap: 5px;
   video {
     position: relative;
     object-fit: cover;
+    width: auto;
   }
   position: absolute;
   top: 0;
@@ -16,7 +17,7 @@ $show-container-gap: 5px;
   transform: translateY(-100%);
   animation: fading $animation-duration linear;
   .childPlayer {
-    width: 106px;
+    width: auto;
     height: 60px;
     box-shadow: 0px 0px 0px 1px rgba(0, 0, 0, 0.2), 0px 8px 60px -16px rgba(0, 0, 0, 0.2);
     border-radius: $roundness-2;
@@ -24,7 +25,6 @@ $show-container-gap: 5px;
     overflow: hidden;
     &.tinyChildPlayer {
       height: 34px;
-      width: 60px;
     }
   }
 


### PR DESCRIPTION
handle pip minimized and tiny dualscreen for content (slides & videos) with bad ratio.

Solves [FEV-1646](https://kaltura.atlassian.net/browse/FEV-1646)

[FEV-1646]: https://kaltura.atlassian.net/browse/FEV-1646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ