### PR TITLE
fix(FEV-1647): Dual screen buttons are available for express recording preview after clicking reply button

### DIFF
--- a/src/dualscreen.tsx
+++ b/src/dualscreen.tsx
@@ -564,10 +564,10 @@ export class DualScreen extends KalturaPlayer.core.BasePlugin implements IEngine
             }
             this._resolveReadyPromise();
           }
-        }
-        else {
+        } else {
           this.logger.warn('SecondaryMediaLoader does not exist');
           this._resolveReadyPromise();
+          this.eventManager.removeAll();
         }
       })
       .catch((e: any) => {


### PR DESCRIPTION
remove plugin listeners if media doesn't have dual-screen