### PR TITLE
fix(FEV-1649): dualscreen expand button tooltip is cut if child player's width is small

### DIFF
--- a/src/components/pip/pip-child.tsx
+++ b/src/components/pip/pip-child.tsx
@@ -70,7 +70,7 @@ export class PipChild extends Component<PIPChildComponentProps> {
   private _renderInnerButtons() {
     const {onSideBySideSwitch, onInversePIP, focusOnButton} = this.props;
     return (
-      <div className={styles.innerButtons}>
+      <div className={[styles.innerButtons, this.props.portrait ? styles.verticalPlayer : ''].join(' ')}>
         <Button
           className={styles.iconContainer}
           onClick={onSideBySideSwitch}

--- a/src/components/pip/pip.scss
+++ b/src/components/pip/pip.scss
@@ -83,6 +83,11 @@ $hide-container-gap: 5px;
       * {
         pointer-events: auto;
       }
+      &.verticalPlayer {
+        :global(.playkit-tooltip span) {
+          max-width: 100px !important;
+        }
+      }
 
       .iconContainer {
         display: inline-block;

--- a/src/dualscreen.tsx
+++ b/src/dualscreen.tsx
@@ -230,7 +230,7 @@ export class DualScreen extends KalturaPlayer.core.BasePlugin implements IEngine
     if (this._layout === Layout.PIP && this._removeActivesArr.length && this._imagePlayer.active?.portrait === this._pipPortraitMode) {
       return;
     }
-    this._pipPortraitMode = this._imagePlayer.active ? this._imagePlayer.active.portrait : this._pipPortraitMode;
+    this._setPipPortraitMode();
     this._layout = Layout.PIP;
 
     this._addActives(
@@ -611,5 +611,15 @@ export class DualScreen extends KalturaPlayer.core.BasePlugin implements IEngine
 
   destroy(): void {
     this.eventManager.destroy();
+  }
+
+  private _setPipPortraitMode() {
+    if (this._secondaryPlayerType === PlayerType.VIDEO && this.secondaryKalturaPlayer) {
+      const secondaryVideoWidth = this.secondaryKalturaPlayer.getVideoElement().videoWidth;
+      const secondaryVideoHeight = this.secondaryKalturaPlayer.getVideoElement().videoHeight;
+      this._pipPortraitMode =  secondaryVideoWidth < secondaryVideoHeight || this._pipPortraitMode;
+    } else {
+      this._pipPortraitMode = this._imagePlayer.active ? this._imagePlayer.active.portrait : this._pipPortraitMode;
+    }
   }
 }


### PR DESCRIPTION
**the issue:**
following a new change, where in pip mode the child player dimensions is dynamic according to the content ratio, in a case where the width is small (~less than 190px) the tooltip of the expand button is cut.

**solution:**
- add `max-width=100` in case the child player is in portrait mode
- support portrait mode also for video and not just for images- according to the video's width and height.

Solves [FEV-1649](https://kaltura.atlassian.net/browse/FEV-1649)

[FEV-1649]: https://kaltura.atlassian.net/browse/FEV-1649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ