### PR TITLE
fix(FEC-13224): slide player missed on multiscreen

### DIFF
--- a/cypress/e2e/dual-screen.cy.ts
+++ b/cypress/e2e/dual-screen.cy.ts
@@ -169,8 +169,7 @@ describe('Dual-Screen plugin', () => {
         });
       });
     });
-    it.skip('should render multiscreen wrapper with 2 players', () => {
-      // TODO: enable test after fix done for image player in multiscreen
+    it('should render multiscreen wrapper with 2 players', () => {
       mockKalturaBe('dual-screen-2-media.json', 'cue-points.json');
       loadPlayer({}, {startTime: 15}).then(() => {
         cy.get('[data-testid="dualscreen_multiscreen"]').within(() => {


### PR DESCRIPTION
solves: https://kaltura.atlassian.net/browse/FEC-13224

There race condition in multiscreen component: if slide cues registered by cue-point manager after multiscreen component got rendered - image player doesn’t appears in multiscreen container.