### PR TITLE
fix(SUP-37810):V7 multi-source entries in Safari

### DIFF
--- a/src/video-sync-manager.ts
+++ b/src/video-sync-manager.ts
@@ -119,7 +119,7 @@ export class VideoSyncManager {
     const seekAhead = 0.25; // s
     //on safari without it the video get stuck on every rate change
     // @ts-ignore
-    const synchDelayDefaultThreshold = this._secondaryPlayer._localPlayer._env.browser.name == "Safari" ? 0.5 : 0;
+    const synchDelayDefaultThreshold = this._secondaryPlayer._localPlayer.env.isSafari ? 0.5 : 0;
     // @ts-ignore
     const synchDelayThreshold = synchDelayDefaultThreshold * this._mainPlayer.playbackRate
 

--- a/src/video-sync-manager.ts
+++ b/src/video-sync-manager.ts
@@ -119,7 +119,7 @@ export class VideoSyncManager {
     const seekAhead = 0.25; // s
     //on safari without it the video get stuck on every rate change
     // @ts-ignore
-    const synchDelayDefaultThreshold = this._secondaryPlayer._localPlayer._env.browser.name == "Safari" ? 0 : 0;
+    const synchDelayDefaultThreshold = this._secondaryPlayer._localPlayer._env.browser.name == "Safari" ? 0.5 : 0;
     // @ts-ignore
     const synchDelayThreshold = synchDelayDefaultThreshold * this._mainPlayer.playbackRate
 

--- a/src/video-sync-manager.ts
+++ b/src/video-sync-manager.ts
@@ -117,6 +117,11 @@ export class VideoSyncManager {
     const synchDelayThresholdNegative = -0.03;
     const maxGap = 4;
     const seekAhead = 0.25; // s
+    //on safari without it the video get stuck on every rate change
+    // @ts-ignore
+    const synchDelayDefaultThreshold = this._secondaryPlayer._localPlayer._env.browser.name == "Safari" ? 0 : 0;
+    // @ts-ignore
+    const synchDelayThreshold = synchDelayDefaultThreshold * this._mainPlayer.playbackRate
 
     if (this._secondaryPlayer) {
       let doSeek = false;
@@ -124,9 +129,9 @@ export class VideoSyncManager {
       this._logger.debug(`mediaSync :: synchDelay is ${synchDelay}`);
       let playbackRateChange = 0;
       const adaptivePlaybackRate = Math.round(Math.abs(synchDelay) * 100) / 100;
-      if (synchDelay > synchDelayThresholdPositive) {
+      if (synchDelay - synchDelayThreshold > synchDelayThresholdPositive) {
         playbackRateChange = -1 * adaptivePlaybackRate;
-      } else if (synchDelay < synchDelayThresholdNegative) {
+      } else if (synchDelay + synchDelayThreshold  < synchDelayThresholdNegative) {
         playbackRateChange = adaptivePlaybackRate;
       }
       if (playbackRateChange !== 0) {

--- a/src/video-sync-manager.ts
+++ b/src/video-sync-manager.ts
@@ -117,7 +117,8 @@ export class VideoSyncManager {
     const synchDelayThresholdNegative = -0.03;
     const maxGap = 4;
     const seekAhead = 0.25; // s
-    //on safari without it the video get stuck on every rate change
+    //relevant for safari only - the video get stuck on every rate change (safari known issue) so it reduce the number of changes.
+    //value of 0.5 is the lowest value that helps with the "jumps" and less harm the video synchronization
     // @ts-ignore
     const synchDelayDefaultThreshold = this._secondaryPlayer._localPlayer.env.isSafari ? 0.5 : 0;
     // @ts-ignore


### PR DESCRIPTION
the issue:
on Safari when run dual screen the video is getting stuck all the time. 

solution:
add sync delay threshold for Safari only to reduce the number of times it change the second player rate
