### PR TITLE
fix(FEC-13260): Side by Side mode: player got paused if primary media moved to multiscreen menu

### DIFF
--- a/src/components/side-by-side/side-by-side.scss
+++ b/src/components/side-by-side/side-by-side.scss
@@ -20,6 +20,9 @@
     padding: 16px;
     justify-content: flex-end;
     animation: appears $animation-duration linear;
+    &.hideButtons {
+      display: none;
+    }
     .buttonWrapper {
       margin-left: 8px;
     }

--- a/src/components/side-by-side/side-by-side.tsx
+++ b/src/components/side-by-side/side-by-side.tsx
@@ -54,28 +54,29 @@ export class SideBySide extends Component<SideBySideComponentProps> {
 
   private _renderHoverButton() {
     const {onExpand, showUi, focusOnButton, multiscreen} = this.props;
-    if (showUi) {
-      return (
-        <Fragment>
-          <div className={styles.innerButtons}>
-            <div className={styles.buttonWrapper}>{cloneElement(multiscreen, {getParentRef: this.props.getParentRef, sbsLayout: true})}</div>
-            <div className={styles.buttonWrapper}>
-              <Button
-                className={styles.iconContainer}
-                onClick={onExpand}
-                tooltip={{label: this.props.expandScreen!, type: 'bottom-left'}}
-                focusOnMount={focusOnButton}
-                type={ButtonType.borderless}
-                size={ButtonSize.medium}
-                icon={'expand'}
-                testId="dualscreen_switchToPIP"
-              />
-            </div>
-          </div>
-        </Fragment>
-      );
+    const styleClass = [styles.innerButtons];
+    if (!showUi) {
+      styleClass.push(styles.hideButtons);
     }
-    return null;
+    return (
+      <Fragment>
+        <div className={styleClass.join(' ')}>
+          <div className={styles.buttonWrapper}>{cloneElement(multiscreen, {getParentRef: this.props.getParentRef, sbsLayout: true})}</div>
+          <div className={styles.buttonWrapper}>
+            <Button
+              className={styles.iconContainer}
+              onClick={onExpand}
+              tooltip={{label: this.props.expandScreen!, type: 'bottom-left'}}
+              focusOnMount={focusOnButton}
+              type={ButtonType.borderless}
+              size={ButtonSize.medium}
+              icon={'expand'}
+              testId="dualscreen_switchToPIP"
+            />
+          </div>
+        </div>
+      </Fragment>
+    );
   }
 
   render({playerWidth, animation}: SideBySideComponentProps) {


### PR DESCRIPTION
soleves: [FEC-13260](https://kaltura.atlassian.net/browse/FEC-13260)

issue caused by video-element of primary player that disappears once player hide UI.
The same solution already implemented for PiP mode: 
https://github.com/kaltura/playkit-js-dual-screen/blob/master/src/components/pip/pip-child.tsx#L143-L145
https://github.com/kaltura/playkit-js-dual-screen/blob/master/src/components/pip/pip.scss#L23

[FEC-13260]: https://kaltura.atlassian.net/browse/FEC-13260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ