### PR TITLE
fix(FEC-13591): disable browser native PiP for dualscreen player

### DIFF
--- a/src/components/pip/pip-child.tsx
+++ b/src/components/pip/pip-child.tsx
@@ -71,6 +71,7 @@ export class PipChild extends Component<PIPChildComponentProps> {
     const {player} = this.props;
     const videoElement = player.getVideoElement();
     videoElement.tabIndex = -1;
+    videoElement.setAttribute('disablePictureInPicture', 'true');
     this.playerContainerRef.current!.prepend(videoElement);
     this.props.setDraggableTarget!(this.playerContainerRef.current!);
   }


### PR DESCRIPTION
disabling the native picture-in-picture functionality of the browsers, for the dualscreen player.

Solves [FEC-13591](https://kaltura.atlassian.net/browse/FEC-13591)

[FEC-13591]: https://kaltura.atlassian.net/browse/FEC-13591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ