### PR TITLE
fix(ADA-1122): Dual screen expand buttons are unlabelled

### DIFF
--- a/src/components/side-by-side/side-by-side.tsx
+++ b/src/components/side-by-side/side-by-side.tsx
@@ -67,6 +67,7 @@ export class SideBySide extends Component<SideBySideComponentProps> {
               className={styles.iconContainer}
               onClick={onExpand}
               tooltip={{label: this.props.expandScreen!, type: 'bottom-left'}}
+              ariaLabel={this.props.expandScreen}
               focusOnMount={focusOnButton}
               type={ButtonType.borderless}
               size={ButtonSize.medium}


### PR DESCRIPTION
Adding aria-label on expand buttons in side by side mode

solves [ADA-1122](https://kaltura.atlassian.net/browse/ADA-1122)

[ADA-1122]: https://kaltura.atlassian.net/browse/ADA-1122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ