### PR TITLE
fix(ADA-1193): Player - Switch to secondary screen label

### DIFF
--- a/src/components/pip/pip-child.tsx
+++ b/src/components/pip/pip-child.tsx
@@ -1,9 +1,10 @@
-import {h, createRef, Component, Fragment, VNode, cloneElement} from 'preact';
+import {cloneElement, Component, createRef, Fragment, h, VNode} from 'preact';
 import * as styles from './pip.scss';
 import {Animations, ButtonsEnum, Layout} from '../../enums';
 import {icons} from '../../icons';
 import {Button, ButtonSize, ButtonType} from '@playkit-js/common/dist/components/button';
 import {OnClick} from '@playkit-js/common/dist/hoc/a11y-wrapper';
+
 const {connect} = KalturaPlayer.ui.redux;
 const {utils, reducers} = KalturaPlayer.ui;
 const {Icon} = KalturaPlayer.ui.components;
@@ -46,6 +47,7 @@ interface PIPChildComponentOwnProps {
   };
   focusOnButton?: ButtonsEnum;
   layout: Layout;
+  setLayout: (layout:Layout)=> void;
 }
 interface PIPChildComponentConnectProps {
   playerHeight?: number;
@@ -74,6 +76,7 @@ export class PipChild extends Component<PIPChildComponentProps> {
     videoElement.setAttribute('disablePictureInPicture', 'true');
     this.playerContainerRef.current!.prepend(videoElement);
     this.props.setDraggableTarget!(this.playerContainerRef.current!);
+    this.props.setLayout(this.props.layout === Layout.PIP? Layout.PIPInverse: Layout.PIP)
   }
 
   private _renderInnerButtons() {

--- a/src/dualscreen.tsx
+++ b/src/dualscreen.tsx
@@ -398,7 +398,6 @@ export class DualScreen extends BasePlugin<DualScreenConfig> implements IEngineD
     if (!force && this._layout === Layout.PIP && this._removeActivesArr.length && imagePlayer.active?.portrait === this._pipPortraitMode) {
       return;
     }
-    this._layout = Layout.PIP;
     this._setPipPortraitMode();
 
     this._addActives(
@@ -435,13 +434,13 @@ export class DualScreen extends BasePlugin<DualScreenConfig> implements IEngineD
                 }
                 onInversePIP={(event: OnClickEvent, byKeyboard: boolean) => {
                   this._applyInverse();
-                  this._layout = Layout.PIPInverse; // toggle layout change
                   this._switchToPIP({animation: Animations.Fade, focusOnButton: getValueOrUndefined(byKeyboard, ButtonsEnum.SwitchScreen)});
                 }}
                 portrait={this._pipPortraitMode}
                 aspectRatio={this.config.childAspectRatio}
                 focusOnButton={focusOnButton}
                 layout={this._layout}
+                setLayout={(layout:Layout)=>{this.layout = layout}}
                 multiscreen={<Multiscreen players={this._makeMultiscreenPlayers(this._getMultiscreenPlayers())} getPosition={this.getPipPosition} />}
               />
             </DragAndSnapManager>


### PR DESCRIPTION
**Issue:** 
"Switch to secondary screen" doesn't change the label to "Switch to primary screen" even you have clicked already the secondary screen

**Solution:**
Change the layout value in the pip-chile after the translation string replacement.

Solves [ADA-1193](https://kaltura.atlassian.net/browse/ADA-1193)

[ADA-1193]: https://kaltura.atlassian.net/browse/ADA-1193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ