### PR TITLE
fix(FEC-14055): fix z-indexes for side panels

### DIFF
--- a/src/components/side-by-side/side-by-side.scss
+++ b/src/components/side-by-side/side-by-side.scss
@@ -71,5 +71,5 @@
 
 :global(.has-dual-screen-plugin-overlay.playkit-hover .playkit-side-panel) {
   // prevent displaying innerButtons over playkit-side-panel
-  z-index: 1;
+  z-index: 2;
 }


### PR DESCRIPTION
Align z-index with https://github.com/kaltura/playkit-js-ui/pull/908

solves: https://kaltura.atlassian.net/browse/FEC-14055