### PR TITLE
fix(SUP-44191):v7 player issues when using picture-in-picture

### DIFF
--- a/src/components/pip/pip-child.tsx
+++ b/src/components/pip/pip-child.tsx
@@ -32,7 +32,6 @@ const mapStateToProps = (state: Record<string, any>) => ({
 interface PIPChildComponentOwnProps {
   multiscreen: VNode;
   player: KalturaPlayerTypes.Player | KalturaPlayerTypes.ImagePlayer;
-  playerType: PlayerType;
   playerSizePercentage: number;
   hide: OnClick;
   onSideBySideSwitch: OnClick;
@@ -75,14 +74,6 @@ export class PipChild extends Component<PIPChildComponentProps> {
     videoElement.setAttribute('disablePictureInPicture', 'true');
     this.playerContainerRef.current!.prepend(videoElement);
     this.props.setDraggableTarget!(this.playerContainerRef.current!);
-  }
-
-  componentWillUnmount(){
-    const {player,playerType} = this.props;
-    if(playerType === PlayerType.VIDEO){
-      const videoElement = player.getVideoElement();
-      videoElement.removeAttribute('disablePictureInPicture');
-    }
   }
 
   private _renderInnerButtons() {

--- a/src/components/pip/pip-parent.tsx
+++ b/src/components/pip/pip-parent.tsx
@@ -1,6 +1,6 @@
 import {h, createRef, Component} from 'preact';
 import * as styles from './pip.scss';
-import {Animations} from '../../enums';
+import {Animations, PlayerType} from '../../enums';
 const {connect} = KalturaPlayer.ui.redux;
 
 const mapStateToProps = (state: Record<string, any>) => ({
@@ -10,6 +10,7 @@ const mapStateToProps = (state: Record<string, any>) => ({
 interface PIPParentComponentOwnProps {
   player: KalturaPlayerTypes.Player | KalturaPlayerTypes.ImagePlayer;
   animation: Animations;
+  playerType: PlayerType;
 }
 interface PIPParentComponentConnectProps {
   prePlayback?: boolean;
@@ -21,7 +22,11 @@ export class PipParent extends Component<PIPParentComponentProps> {
   videoContainerRef = createRef<HTMLDivElement>();
 
   componentDidMount() {
-    const {player} = this.props;
+    const {player,playerType} = this.props;
+    if(playerType === PlayerType.VIDEO){
+      const videoElement = player.getVideoElement();
+      videoElement.removeAttribute('disablePictureInPicture');
+    }
     this.videoContainerRef?.current?.appendChild(player.getVideoElement());
   }
 

--- a/src/components/side-by-side/side-by-side.tsx
+++ b/src/components/side-by-side/side-by-side.tsx
@@ -48,6 +48,7 @@ export class SideBySide extends Component<SideBySideComponentProps> {
 
   componentDidMount() {
     const videoElement = this.props.player.getVideoElement();
+    videoElement.setAttribute('disablePictureInPicture', 'true');
     videoElement.tabIndex = -1;
     this.ref.current.prepend(videoElement);
   }

--- a/src/dualscreen.tsx
+++ b/src/dualscreen.tsx
@@ -409,7 +409,11 @@ export class DualScreen extends BasePlugin<DualScreenConfig> implements IEngineD
         label: 'kaltura-dual-screen-pip',
         presets: PRESETS,
         container: ReservedPresetAreas.VideoContainer,
-        get: () => <PipParent animation={animation} player={this.getActiveDualScreenPlayer(PlayerContainers.primary)!.player as any} />
+        get: () => <PipParent
+          animation={animation}
+          player={this.getActiveDualScreenPlayer(PlayerContainers.primary)!.player as any}
+          playerType={this.getActiveDualScreenPlayer(PlayerContainers.primary)!.type as PlayerType}
+        />
       }),
       this.player.ui.addComponent({
         label: 'kaltura-dual-screen-pip',
@@ -430,7 +434,6 @@ export class DualScreen extends BasePlugin<DualScreenConfig> implements IEngineD
                 animation={Animations.Fade}
                 playerSizePercentage={this.config.childSizePercentage}
                 player={this.getActiveDualScreenPlayer(PlayerContainers.secondary)!.player as any}
-                playerType={this.getActiveDualScreenPlayer(PlayerContainers.secondary)!.type as PlayerType}
                 hide={(event: OnClickEvent, byKeyboard: boolean) =>
                   this._switchToSingleMedia({animation: Animations.None, focusOnButton: getValueOrUndefined(byKeyboard, ButtonsEnum.Show)})
                 }
@@ -469,7 +472,11 @@ export class DualScreen extends BasePlugin<DualScreenConfig> implements IEngineD
         label: 'kaltura-dual-screen-pip',
         presets: PRESETS,
         container: ReservedPresetAreas.VideoContainer,
-        get: () => <PipParent animation={animation} player={this.getActiveDualScreenPlayer(PlayerContainers.primary)!.player as any} />
+        get: () => <PipParent
+          animation={animation}
+          player={this.getActiveDualScreenPlayer(PlayerContainers.primary)!.player as any}
+          playerType={this.getActiveDualScreenPlayer(PlayerContainers.primary)!.type as PlayerType}
+        />
       }),
       this.player.ui.addComponent({
         label: 'kaltura-dual-screen-pip-minimized',


### PR DESCRIPTION
issue:
on dual screen, at first time can click on PIP button and video changed to PIP, once changes the streams and change it back when click on PIP it not working anymore
fix was provided but qa found that PIP will also be enabled after click hide button

fix:
enable pip in the parent instead of in the child, also add disable for PIP in case click on side-by-side button.

solved [SUP-44191](https://kaltura.atlassian.net/browse/SUP-44191)

[SUP-44191]: https://kaltura.atlassian.net/browse/SUP-44191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ