### PR TITLE
fix(SUP-44191):v7 player issues when using picture-in-picture

### DIFF
--- a/src/components/pip-minimized/pip-minimized.tsx
+++ b/src/components/pip-minimized/pip-minimized.tsx
@@ -42,6 +42,7 @@ export class PipMinimized extends Component<PIPMinimizedProps> {
     this._multiscreenPlayersRefs.forEach((ref, index) => {
       const videoElement = this.props.players[index].player.getVideoElement();
       videoElement.tabIndex = -1;
+      videoElement.setAttribute('disablePictureInPicture', 'true');
       ref.current!.prepend(videoElement);
     });
   }


### PR DESCRIPTION
issue:
on dual screen, at first time can click on PIP button and video changed to PIP, once changes the streams and change it back when click on PIP it not working anymore
fix was provided but qa found that PIP will also be enabled when click hide on second stream and then switch streams

fix:
disable pip in minimised player 

solved [SUP-44191](https://kaltura.atlassian.net/browse/SUP-44191)

[SUP-44191]: https://kaltura.atlassian.net/browse/SUP-44191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ