### PR TITLE
fix(SUP-38407): [GaTech] [Multistream - V7 Player] Child entries not loading high quality flavor assets

### DIFF
--- a/src/dualscreen.tsx
+++ b/src/dualscreen.tsx
@@ -201,7 +201,7 @@ export class DualScreen extends BasePlugin<DualScreenConfig> implements IEngineD
         }
       }
     });
-    this.eventManager.listen(this.player, EventType.VIDEO_TRACK_CHANGED, (event) => {
+    this.eventManager.listen(this.player, EventType.VIDEO_TRACK_CHANGED, event => {
       this._changeQuality(event.payload.selectedVideoTrack.label);
     });
   }
@@ -235,17 +235,17 @@ export class DualScreen extends BasePlugin<DualScreenConfig> implements IEngineD
 
   private _changeQuality = (label: string) => {
     this._dualScreenPlayers.forEach(dualScreenPlayer => {
-      if(dualScreenPlayer.id != 'mainPlayer' && dualScreenPlayer.id != 'imagePlayer'){
+      if (dualScreenPlayer.id !== MAIN_PLAYER_ID && dualScreenPlayer.id !== IMAGE_PLAYER_ID) {
         //@ts-expect-error
         const videoTrack = dualScreenPlayer.player.getTracks('video');
         const selectedVideoTrack = videoTrack.find((track: any) => track.label === label);
-        if (selectedVideoTrack){
+        if (selectedVideoTrack) {
           //@ts-expect-error
           dualScreenPlayer.player.changeChildQuality(selectedVideoTrack);
         }
       }
     });
-  }
+  };
 
   private _setActiveDualScreenPlayer = (id: string, container: PlayerContainers.primary | PlayerContainers.secondary) => {
     if (this.getActiveDualScreenPlayer(container)?.id === id) {

--- a/src/dualscreen.tsx
+++ b/src/dualscreen.tsx
@@ -201,6 +201,9 @@ export class DualScreen extends BasePlugin<DualScreenConfig> implements IEngineD
         }
       }
     });
+    this.eventManager.listen(this.player, EventType.VIDEO_TRACK_CHANGED, (event) => {
+      this._changeQuality(event.payload.selectedVideoTrack.label);
+    });
   }
 
   public getDualScreenPlayer = (id: string) => {
@@ -229,6 +232,20 @@ export class DualScreen extends BasePlugin<DualScreenConfig> implements IEngineD
     // protection for edge-cases when layout already changed but slides doesn't ready
     return thumbs[0] && thumbs[1] ? thumbs : thumbs[0] ?? thumbs[1];
   };
+
+  private _changeQuality = (label: string) => {
+    this._dualScreenPlayers.forEach(dualScreenPlayer => {
+      if(dualScreenPlayer.id != 'mainPlayer' && dualScreenPlayer.id != 'imagePlayer'){
+        //@ts-expect-error
+        const videoTrack = dualScreenPlayer.player.getTracks('video');
+        const selectedVideoTrack = videoTrack.find((track: any) => track.label === label);
+        if (selectedVideoTrack){
+          //@ts-expect-error
+          dualScreenPlayer.player.changeChildQuality(selectedVideoTrack);
+        }
+      }
+    });
+  }
 
   private _setActiveDualScreenPlayer = (id: string, container: PlayerContainers.primary | PlayerContainers.secondary) => {
     if (this.getActiveDualScreenPlayer(container)?.id === id) {

--- a/src/dualscreen.tsx
+++ b/src/dualscreen.tsx
@@ -241,7 +241,7 @@ export class DualScreen extends BasePlugin<DualScreenConfig> implements IEngineD
         const selectedVideoTrack = videoTrack.find((track: any) => track.label === label);
         if (selectedVideoTrack) {
           //@ts-expect-error
-          dualScreenPlayer.player.changeChildQuality(selectedVideoTrack);
+          dualScreenPlayer.player.changeQuality(selectedVideoTrack);
         }
       }
     });


### PR DESCRIPTION
Issue:
Quality is not changed in childe entries when it is changed in the parent entry.

**Fix:**
Add listener to videotrackchange and change the quality manually to all the other entries.

part of - https://github.com/kaltura/playkit-js/pull/793, https://github.com/kaltura/kaltura-player-js/pull/851

solves [SUP-38407](https://kaltura.atlassian.net/browse/SUP-38407)

[SUP-38407]: https://kaltura.atlassian.net/browse/SUP-38407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ