### PR TITLE
fix(FEC-14031): DUAL_SCREEN_CHANGE_LAYOUT is being sent upon every entry change in playlist

### DIFF
--- a/src/dualscreen.tsx
+++ b/src/dualscreen.tsx
@@ -442,9 +442,7 @@ export class DualScreen extends BasePlugin<DualScreenConfig> implements IEngineD
 
     const mainPlayer = this.getDualScreenPlayer(MAIN_PLAYER_ID);
     const layout = mainPlayer?.container === PlayerContainers.primary ? Layout.PIP : Layout.PIPInverse;
-    if (userInteraction) {
-      this.updateLayout(layout);
-    }
+    this.updateLayout(layout, userInteraction);
 
     this._setPipPortraitMode();
 
@@ -513,9 +511,7 @@ export class DualScreen extends BasePlugin<DualScreenConfig> implements IEngineD
     if (!force && this._layout === Layout.SingleMedia && this._removeActivesArr.length) {
       return;
     }
-    if (userInteraction) {
-      this.updateLayout(Layout.SingleMedia);
-    }
+    this.updateLayout(Layout.SingleMedia, userInteraction);
 
     this._addActives(
       this.player.ui.addComponent({
@@ -555,9 +551,7 @@ export class DualScreen extends BasePlugin<DualScreenConfig> implements IEngineD
     if (!force && this._layout === Layout.SideBySide && this._removeActivesArr.length) {
       return;
     }
-    if (userInteraction) {
-      this.updateLayout(Layout.SideBySide);
-    }
+    this.updateLayout(Layout.SideBySide, userInteraction);
 
     const leftSideProps = {
       player: this.getActiveDualScreenPlayer(PlayerContainers.primary)!.player as any,

--- a/src/dualscreen.tsx
+++ b/src/dualscreen.tsx
@@ -209,7 +209,7 @@ export class DualScreen extends BasePlugin<DualScreenConfig> implements IEngineD
           this._switchToHidden(userInteraction);
         } else {
           this._setDefaultMode(false);
-          this._setMode(userInteraction);
+          this._setMode(undefined, userInteraction);
         }
       }
     });
@@ -730,7 +730,7 @@ export class DualScreen extends BasePlugin<DualScreenConfig> implements IEngineD
             this.eventManager.listenOnce(secondaryPlayer, EventType.FIRST_PLAYING, () => {
               this.logger.debug('secondary player first playing - show dual mode');
               this._setDefaultMode(false);
-              this._setMode(userInteraction);
+              this._setMode(undefined, userInteraction);
               this._firstPlayingFired = true;
             });
           } else {

--- a/src/dualscreen.tsx
+++ b/src/dualscreen.tsx
@@ -639,7 +639,7 @@ export class DualScreen extends BasePlugin<DualScreenConfig> implements IEngineD
     this._applyExternalLayout();
   };
 
-  private _applyExternalLayout = () => {
+  private _applyExternalLayout = (userInteraction = false) => {
     // external layout applies by Kaltura Webcast Studion app, that support only 1 media and slides
     const primaryPlayer = this.getActiveDualScreenPlayer(PlayerContainers.primary);
     const secondaryPlayer = this.getActiveDualScreenPlayer(PlayerContainers.secondary);
@@ -652,42 +652,42 @@ export class DualScreen extends BasePlugin<DualScreenConfig> implements IEngineD
     };
     switch (this._externalLayout) {
       case ExternalLayout.Hidden:
-        this._switchToHidden();
+        this._switchToHidden(userInteraction);
         break;
       case ExternalLayout.SingleMedia:
         if (this._layout !== Layout.SingleMedia || !_checkPlayerContainers()) {
           _applyPlayerContainers();
-          this._switchToSingleMedia({force: true});
+          this._switchToSingleMedia({force: true}, userInteraction);
         }
         break;
       case ExternalLayout.SingleMediaInverse:
         if (this._layout !== Layout.SingleMediaInverse || !_checkPlayerContainers(true)) {
           _applyPlayerContainers(true);
-          this._switchToSingleMedia({force: true});
+          this._switchToSingleMedia({force: true}, userInteraction);
         }
         break;
       case ExternalLayout.PIP:
         if (this._layout !== Layout.PIP || !_checkPlayerContainers()) {
           _applyPlayerContainers();
-          this._switchToPIP({force: true});
+          this._switchToPIP({force: true}, userInteraction);
         }
         break;
       case ExternalLayout.PIPInverse:
         if (this._layout !== Layout.PIPInverse || !_checkPlayerContainers(true)) {
           _applyPlayerContainers(true);
-          this._switchToPIP({force: true});
+          this._switchToPIP({force: true}, userInteraction);
         }
         break;
       case ExternalLayout.SideBySide:
         if (this._layout !== Layout.SideBySide || !_checkPlayerContainers()) {
           _applyPlayerContainers();
-          this._switchToSideBySide({force: true});
+          this._switchToSideBySide({force: true}, userInteraction);
         }
         break;
       case ExternalLayout.SideBySideInverse:
         if (this._layout !== Layout.SideBySideInverse || !_checkPlayerContainers(true)) {
           _applyPlayerContainers(true);
-          this._switchToSideBySide({force: true});
+          this._switchToSideBySide({force: true}, userInteraction);
         }
         break;
     }


### PR DESCRIPTION
### Description of the Changes

- Changed function 'set _layout' to function 'updateLayout'.
- Added a new boolean variable called 'userInteraction' with default value 'true'.
- The function 'updateLayout' gets 'userInteraction =  true' only in places where the user in fact clicked to change layout.
- Added a new boolean variable called 'userInteraction' with default value 'false' to functions '_addBindings' and '_getSecondaryMedia' that being called during every entry 'loadMeida'.
- Added a new boolean variable called 'userInteraction' with default value 'true' to the next functions:
'_setMode', '_setDefaultMode, '_switchToHidden', '_switchToPIP', '_switchToSingleMedia', '_switchToSideBySide'.
- Calling functions that update layout via 'reset' function with 'userInteraction = false'

[FEC-14031](https://kaltura.atlassian.net/browse/FEC-14031)


[FEC-14031]: https://kaltura.atlassian.net/browse/FEC-14031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ