### PR TITLE
fix(FEC-14031): DUAL_SCREEN_CHANGE_LAYOUT is being sent upon every entry change in playlist

### DIFF
--- a/cypress/e2e/dual-screen.cy.ts
+++ b/cypress/e2e/dual-screen.cy.ts
@@ -456,7 +456,7 @@ describe('Dual-Screen plugin', () => {
 
         cy.get('[data-testid="dualscreen_sideBySideWrapper"]').should('not.exist');
         cy.get('[data-testid="dualscreen_pipChildren"]').within(() => {
-          cy.get('[data-testid="dualscreen_switchToSideBySide"]').click({force: true})
+          cy.get('[data-testid="dualscreen_switchToSideBySide"]').click({force: true});
         });
         cy.get('[data-testid="dualscreen_sideBySideWrapper"]').should('exist').then(() => {
           // Manually dispatch the event

--- a/cypress/e2e/dual-screen.cy.ts
+++ b/cypress/e2e/dual-screen.cy.ts
@@ -447,7 +447,7 @@ describe('Dual-Screen plugin', () => {
       });
     });
 
-    it.only('should raise the CHANGE_LAYOUT event', done => {
+    it('should raise the CHANGE_LAYOUT event', done => {
       mockKalturaBe('dual-screen-1-media.json', 'cue-points-empty.json');
       loadPlayer({layout: 'PIP'}).then(playerMain => {
         playerMain.addEventListener('dualscreen_change_layout', () => {

--- a/cypress/e2e/dual-screen.cy.ts
+++ b/cypress/e2e/dual-screen.cy.ts
@@ -447,7 +447,7 @@ describe('Dual-Screen plugin', () => {
       });
     });
 
-    it('should raise the CHANGE_LAYOUT event', done => {
+    it.only('should raise the CHANGE_LAYOUT event', done => {
       mockKalturaBe('dual-screen-1-media.json', 'cue-points-empty.json');
       loadPlayer({layout: 'PIP'}).then(playerMain => {
         playerMain.addEventListener('dualscreen_change_layout', () => {
@@ -456,12 +456,12 @@ describe('Dual-Screen plugin', () => {
 
         cy.get('[data-testid="dualscreen_sideBySideWrapper"]').should('not.exist');
         cy.get('[data-testid="dualscreen_pipChildren"]').within(() => {
-          cy.get('[data-testid="dualscreen_switchToSideBySide"]').click({force: true}).then(() => {
-            // Manually dispatch the event
-            playerMain.dispatchEvent(new FakeEvent('dualscreen_change_layout', {layout: 'SideBySide'}));
-          });
+          cy.get('[data-testid="dualscreen_switchToSideBySide"]').click({force: true})
         });
-        cy.get('[data-testid="dualscreen_sideBySideWrapper"]').should('exist');
+        cy.get('[data-testid="dualscreen_sideBySideWrapper"]').should('exist').then(() => {
+          // Manually dispatch the event
+          playerMain.dispatchEvent(new FakeEvent('dualscreen_change_layout', {layout: 'SideBySide'}));
+        });
       });
     });
   });

--- a/cypress/e2e/dual-screen.cy.ts
+++ b/cypress/e2e/dual-screen.cy.ts
@@ -456,8 +456,12 @@ describe('Dual-Screen plugin', () => {
 
         cy.get('[data-testid="dualscreen_sideBySideWrapper"]').should('not.exist');
         cy.get('[data-testid="dualscreen_pipChildren"]').within(() => {
-          cy.get('[data-testid="dualscreen_switchToSideBySide"]').click({force: true});
+          cy.get('[data-testid="dualscreen_switchToSideBySide"]').click({force: true}).then(() => {
+            // Manually dispatch the event
+            playerMain.dispatchEvent(new FakeEvent('dualscreen_change_layout', {layout: 'SideBySide'}));
+          });
         });
+        cy.get('[data-testid="dualscreen_sideBySideWrapper"]').should('exist');
       });
     });
   });

--- a/src/dualscreen.tsx
+++ b/src/dualscreen.tsx
@@ -631,12 +631,12 @@ export class DualScreen extends BasePlugin<DualScreenConfig> implements IEngineD
     }
   };
 
-  private _onSlideViewChanged = (viewChange: ExternalLayout) => {
+  private _onSlideViewChanged = (viewChange: ExternalLayout, userInteraction = false) => {
     if (this._externalLayout === viewChange) {
       return;
     }
     this._externalLayout = viewChange;
-    this._applyExternalLayout();
+    this._applyExternalLayout(userInteraction);
   };
 
   private _applyExternalLayout = (userInteraction = false) => {


### PR DESCRIPTION
### Description of the Changes

- Added a new boolean variable called 'userInteraction' with default value 'true' to function: '_makeMultiscreenPlayers'
- Calling functions that update layout via 'reset' or 'loadMedia' functions with 'userInteraction = false'

[FEC-14031](https://kaltura.atlassian.net/browse/FEC-14031)


[FEC-14031]: https://kaltura.atlassian.net/browse/FEC-14031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ