### PR TITLE
fix(SUP-45743): Errors on playback for mulitstream

### DIFF
--- a/src/video-sync-manager.ts
+++ b/src/video-sync-manager.ts
@@ -30,9 +30,13 @@ export class VideoSyncManager {
   private _errorHandling = () => {
     this._eventManager.listen(this._secondaryPlayer, EventType.ERROR, (e: Error) => {
       this._logger.debug('errorHandling :: secondary player got error');
+      const error = new Error(Error.Severity.CRITICAL, Error.Category.PLAYER, Error.Code.VIDEO_ERROR, e);
+      // @ts-ignore
+      this._mainPlayer.dispatchEvent(new FakeEvent(EventType.ERROR, error));
     });
     this._eventManager.listen(this._mainPlayer, EventType.ERROR, () => {
       this._logger.debug('errorHandling :: main player got error');
+      this._secondaryPlayer.reset();
     });
   };
 

--- a/src/video-sync-manager.ts
+++ b/src/video-sync-manager.ts
@@ -30,14 +30,9 @@ export class VideoSyncManager {
   private _errorHandling = () => {
     this._eventManager.listen(this._secondaryPlayer, EventType.ERROR, (e: Error) => {
       this._logger.debug('errorHandling :: secondary player got error');
-      const error = new Error(Error.Severity.CRITICAL, Error.Category.PLAYER, Error.Code.VIDEO_ERROR, e);
-      this._mainPlayer.pause();
-      // @ts-ignore
-      this._mainPlayer.dispatchEvent(new FakeEvent(EventType.ERROR, error));
     });
     this._eventManager.listen(this._mainPlayer, EventType.ERROR, () => {
       this._logger.debug('errorHandling :: main player got error');
-      this._secondaryPlayer.reset();
     });
   };
 


### PR DESCRIPTION
**Issue:**
When get parsing error with No media found, the video stops and a black screen is appear.
In dual screen - the player presents an Error Overlay.

**Fix:**
Mimic the behavior in V2 player, stop the video with the error and not show a black screen while the other player keep's playing.

[solved] (https://kaltura.atlassian.net/browse/SUP-45743)