### PR TITLE
fix(SUP-47737): something went wrong message for v7 player

### DIFF
--- a/src/video-sync-manager.ts
+++ b/src/video-sync-manager.ts
@@ -30,13 +30,12 @@ export class VideoSyncManager {
   private _errorHandling = () => {
     this._eventManager.listen(this._secondaryPlayer, EventType.ERROR, (e: Error) => {
       this._logger.debug('errorHandling :: secondary player got error');
-      const error = new Error(Error.Severity.CRITICAL, Error.Category.PLAYER, Error.Code.VIDEO_ERROR, e);
+      const error = new Error(Error.Severity.RECOVERABLE, Error.Category.PLAYER, Error.Code.VIDEO_ERROR, e);
       // @ts-ignore
       this._mainPlayer.dispatchEvent(new FakeEvent(EventType.ERROR, error));
     });
     this._eventManager.listen(this._mainPlayer, EventType.ERROR, () => {
       this._logger.debug('errorHandling :: main player got error');
-      this._secondaryPlayer.reset();
     });
   };
 


### PR DESCRIPTION
**Issue:**
When parsing error occurs on the secondary entry, it makes the whole player to fail.

**Fix:**
Instead of sent to the main player a critical error, send it a recovery error, and not reset the secondary player.

solved https://kaltura.atlassian.net/browse/SUP-47737
This bug was already fixed for this ticket: https://kaltura.atlassian.net/browse/SUP-45743
but the problem is replicated again.