### PR TITLE
fix(SUP-48038): UC-Berkeley | Dual Stream Preview Not Working for up-to-date V7 Players

### DIFF
--- a/src/dualscreen.tsx
+++ b/src/dualscreen.tsx
@@ -83,11 +83,6 @@ export class DualScreen extends BasePlugin<DualScreenConfig> implements IEngineD
       ready: this.ready
     };
     this.player.registerService('dualScreen', dualScreenApi);
-    if (this.timelineManager) {
-      this.player.ready().then(() => {
-        this.timelineManager.setGetThumbnailInfo(this.getDualScreenThumbs);
-      });
-    }
   }
 
   getEngineDecorator(engine: any, dispatcher: Function) {
@@ -153,6 +148,11 @@ export class DualScreen extends BasePlugin<DualScreenConfig> implements IEngineD
       this._imageSyncManager = new ImageSyncManager(this.eventManager, this.player, imagePlayer as any, this.logger, this._onSlideViewChanged);
     } else {
       this.logger.warn('kalturaCuepoints service is not registered');
+    }
+    if (this.timelineManager) {
+      this.player.ready().then(() => {
+        this.timelineManager.setGetThumbnailInfo(this.getDualScreenThumbs);
+      });
     }
   }
 


### PR DESCRIPTION
**Issue:**
dual screen thumbnails is not shown on the timeline. only the primary video thumbnail is shown.

**Root cause:**
we check the timelineMamager before it's initialized.

**Fix:** 
Move the functionality into loadMedia

solve [SUP-48038](https://kaltura.atlassian.net/browse/SUP-48038)

[SUP-48038]: https://kaltura.atlassian.net/browse/SUP-48038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ