### PR TITLE
fix(FEC-14575): As client running multiple player on Dual screen plugin, I would like the non-primary players to inherit config from the primary

### DIFF
--- a/src/dualscreen.tsx
+++ b/src/dualscreen.tsx
@@ -802,6 +802,8 @@ export class DualScreen extends BasePlugin<DualScreenConfig> implements IEngineD
     secondaryPlaceholder.style.height = '135px';
     secondaryPlaceholder.hidden = true;
     document.body.appendChild(secondaryPlaceholder);
+    // @ts-ignore
+    const {entryId: id, entryType, ...filteredConfig} = this.player.plugins['kava']?.config || {}
     const secondaryPlayerConfig = {
       targetId,
       disableUserCache: true,
@@ -823,8 +825,7 @@ export class DualScreen extends BasePlugin<DualScreenConfig> implements IEngineD
           ...(this.player.plugins['kaltura-live']?.config || {})
         },
         'kava':{
-          // @ts-ignore
-          ...(this.player.plugins['kava']?.config || {})
+          ...filteredConfig
         }
       }
     };

--- a/src/dualscreen.tsx
+++ b/src/dualscreen.tsx
@@ -821,6 +821,10 @@ export class DualScreen extends BasePlugin<DualScreenConfig> implements IEngineD
         'kaltura-live': {
           // @ts-ignore
           ...(this.player.plugins['kaltura-live']?.config || {})
+        },
+        'kava':{
+          // @ts-ignore
+          ...(this.player.plugins['kava']?.config || {})
         }
       }
     };


### PR DESCRIPTION
**Issue:** 
When changing configuration in kava plugin, config is changed only on primary player and not also in child player.

Fix:
Add kava plugin configuration from primary player on child players.

Solves [FEC-14575](https://kaltura.atlassian.net/browse/FEC-14575)

[FEC-14575]: https://kaltura.atlassian.net/browse/FEC-14575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ