### PR TITLE
fix(FEC-14903): Player v7| add KS in runtime using API doesnt work on dual screen entreis on the secodnrey thumbnail

### DIFF
--- a/src/dualscreen.tsx
+++ b/src/dualscreen.tsx
@@ -226,15 +226,6 @@ export class DualScreen extends BasePlugin<DualScreenConfig> implements IEngineD
     });
   }
 
-  private _updateThumbnailUrl(newKs: string) {
-    this._dualScreenPlayers.forEach(dualScreenPlayer => {
-      if (dualScreenPlayer.type === PlayerType.VIDEO) {
-        // @ts-ignore
-        dualScreenPlayer.player.updateThumbnailKs(newKs, false);
-      }
-    });
-  }
-
   public getDualScreenPlayer = (id: string) => {
     return this._dualScreenPlayers.find(dualScreenPlayer => {
       return dualScreenPlayer.id === id;
@@ -284,6 +275,15 @@ export class DualScreen extends BasePlugin<DualScreenConfig> implements IEngineD
       }
     });
     
+  }
+
+  private _updateThumbnailUrl(newKs: string) {
+    this._dualScreenPlayers.forEach(dualScreenPlayer => {
+      if (dualScreenPlayer.type === PlayerType.VIDEO) {
+        // @ts-ignore
+        dualScreenPlayer.player.updateThumbnailKs(newKs, false);
+      }
+    });
   }
 
   private _changeQuality = (label: string) => {

--- a/src/dualscreen.tsx
+++ b/src/dualscreen.tsx
@@ -221,6 +221,18 @@ export class DualScreen extends BasePlugin<DualScreenConfig> implements IEngineD
        this._changeQuality(event.payload.selectedVideoTrack.label);
      }
     });
+     this.eventManager.listen(this.player, EventType.THUMBNAIL_KS_UPDATED, event => {
+      this._updateThumbnailUrl(event.payload.newKs);
+    });
+  }
+
+  private _updateThumbnailUrl(newKs: string) {
+    this._dualScreenPlayers.forEach(dualScreenPlayer => {
+      if (dualScreenPlayer.type === PlayerType.VIDEO) {
+        // @ts-ignore
+        dualScreenPlayer.player.updateThumbnailKs(newKs, false);
+      }
+    });
   }
 
   public getDualScreenPlayer = (id: string) => {


### PR DESCRIPTION
**Issue:**
when sending ks from hosting page in order to reload thumbnail url, the dual screen player thumbnails doesn't reload with the new ks.

**Root cause:**
The player update only the thumbnail of the main player.

**FIx:**
When ks is updated, go over all dual screen players and update the ks for each one.

related pr - https://github.com/kaltura/kaltura-player-js/pull/1188, https://github.com/kaltura/playkit-js/pull/865

solves [FEC-14903](https://kaltura.atlassian.net/browse/FEC-14903)

[FEC-14903]: https://kaltura.atlassian.net/browse/FEC-14903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ