### PR TITLE
fix(SUP-52693): bumper not loading properly via Live Studio

### DIFF
--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -16,4 +16,7 @@
   :global(.playkit-picture-in-picture-overlay) {
     visibility: hidden;
   }
+  :global(.playkit-bumper-container) {
+    z-index: 1;
+  }
 }


### PR DESCRIPTION
issue:
when there is bumper and dual screen with slide, in the middle of the bumper the slide is showen

solution:
add z-index for bumper when there is dual screen and bumper so the bumper will be on top

solve [SUP-52693](https://kaltura.atlassian.net/browse/SUP-52693)

[SUP-52693]: https://kaltura.atlassian.net/browse/SUP-52693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ