### PR TITLE
fix(SUP-52949): Live Studio – Video Feed Not Returning After Slides Are Stopped

### DIFF
--- a/src/dualscreen.tsx
+++ b/src/dualscreen.tsx
@@ -197,11 +197,11 @@ export class DualScreen extends BasePlugin<DualScreenConfig> implements IEngineD
   };
 
   private _addBindings(userInteraction = false) {
+    this.eventManager.listen(this.player, EventType.CHANGE_SOURCE_ENDED, () => {
+      this._originalVideoElementParent = this.player.getVideoElement().parentElement!;
+    });
     this.eventManager.listen(this.player, EventType.PLAYBACK_ENDED, () => {
       this._playbackEnded = true;
-    });
-    this.eventManager.listenOnce(this.player, EventType.FIRST_PLAY, () => {
-      this._originalVideoElementParent = this.player.getVideoElement().parentElement!;
     });
     this.eventManager.listen(this.player, EventType.PLAY, () => {
       if (this._playbackEnded) {
@@ -471,10 +471,10 @@ export class DualScreen extends BasePlugin<DualScreenConfig> implements IEngineD
     this.updateLayout(Layout.Hidden, userInteraction);
     // @ts-ignore
     dispatch(shell.actions.removePlayerClass(HAS_DUAL_SCREEN_PLUGIN_OVERLAY));
-    this._removeActives();
     if (this._originalVideoElementParent) {
       this._originalVideoElementParent.prepend(this.player.getVideoElement());
     }
+    this._removeActives();
   };
 
   private _switchToPIP = ({animation = Animations.None, focusOnButton, force}: LayoutChangeProps = {}, userInteraction = false) => {
@@ -848,6 +848,9 @@ export class DualScreen extends BasePlugin<DualScreenConfig> implements IEngineD
   }
 
   destroy(): void {
+    if (this._originalVideoElementParent) {
+      this._originalVideoElementParent.prepend(this.player.getVideoElement());
+    }
     this.eventManager.destroy();
   }
 

--- a/src/dualscreen.tsx
+++ b/src/dualscreen.tsx
@@ -848,9 +848,6 @@ export class DualScreen extends BasePlugin<DualScreenConfig> implements IEngineD
   }
 
   destroy(): void {
-    if (this._originalVideoElementParent) {
-      this._originalVideoElementParent.prepend(this.player.getVideoElement());
-    }
     this.eventManager.destroy();
   }
 


### PR DESCRIPTION
**Issue:** After stopping slide sharing in a Live Studio session, the video feed disappears (white screen). Audio continues but video never returns.

**Root cause:** The `<video>` element ends up under `playkit-bumper-container` instead of `playkit-container`. `_originalVideoElementParent` was captured on `FIRST_PLAY`, but by that time the bumper plugin may already be playing and have taken ownership of the DOM — so the snapshot points to `playkit-bumper-container` instead of the native `playkit-container`. When slides stop, `_switchToHidden()` restores the `<video>` element back to the bumper container, leaving `playkit-container` empty. Additionally, `_switchToHidden()` called `_removeActives()` before restoring the video element, briefly orphaning `<video>` from the DOM — enough to corrupt the MSE/hls.js pipeline.

**Fix:** Capture `_originalVideoElementParent` on `CHANGE_SOURCE_ENDED` instead of `FIRST_PLAY`. This event fires after the player finishes loading a new source, while the video element is in its native container before any plugin (including bumper) touches it. Also reorder `_switchToHidden()` to restore the video element before unmounting Preact components, and add the same restore to `destroy()` as a safety guard.

[SUP-52949](https://kaltura.atlassian.net/browse/SUP-52949)

[SUP-52949]: https://kaltura.atlassian.net/browse/SUP-52949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ